### PR TITLE
Release portworx test-version (automated commit)



### DIFF
--- a/repo/packages/P/portworx/2/command.json
+++ b/repo/packages/P/portworx/2/command.json
@@ -1,0 +1,5 @@
+{
+  "pip": [
+    "https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/bin_wrapper-0.0.1-py2.py3-none-any.whl"
+  ]
+}

--- a/repo/packages/P/portworx/2/config.json
+++ b/repo/packages/P/portworx/2/config.json
@@ -1,0 +1,220 @@
+{
+  "type": "object",
+    "properties": {
+      "service": {
+        "type": "object",
+        "description": "DC/OS service configuration properties",
+        "properties": {
+          "name": {
+            "title": "Service name",
+            "description": "The name of the service instance",
+            "type": "string",
+            "default": "portworx"
+          },
+          "principal": {
+            "title": "Custom principal (optional)",
+            "description": "The principal for the service instance, or empty to use the default.",
+            "type": "string",
+            "default": ""
+          },
+          "secret_name": {
+            "title": "Credential secret name (optional)",
+            "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+            "type": "string",
+            "default": ""
+          }
+        },
+        "required":[
+          "name"
+        ]
+      },
+      "node": {
+        "description": "Portworx Node properties",
+        "type": "object",
+        "properties": {
+          "portworx_cluster": {
+            "title": "Portworx Cluster Name",
+            "type": "string",
+            "default":"portworx-dcos"
+          },
+          "portworx_image": {
+            "title": "Portworx Image name",
+            "type": "string",
+            "default":"px-dev:latest"
+          },
+          "portworx_options": {
+            "title": "Portworx Options",
+            "type": "string",
+            "default":"-a"
+          },
+          "kvdb_servers": {
+            "title":"KVDB servers",
+            "description": "Comma seperated IP:PORT entries for the key value database (etcd or consul). If the etcd server is started using the pacakge this will be ignored",
+            "type": "string",
+            "default": ""
+          },
+          "count": {
+            "title": "Node count",
+            "description": "Number of Portworx nodes to run",
+            "type": "integer",
+            "default":3
+          },
+          "placement_constraint": {
+            "title": "Placement constraint",
+            "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+            "type": "string",
+            "default": "hostname:UNIQUE"
+          }
+        },
+        "required":[
+          "count",
+          "portworx_cluster",
+          "portworx_image",
+          "portworx_options"
+        ]
+      },
+      "etcd": {
+        "description": "Start a 3 node etcd cluster. Required for Portworx if you don't have either etcd or consul already running",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "title": "Start etcd",
+            "description": "If disabled, please enter the external etcd server IP on the service tab.",
+            "type": "boolean",
+            "default":true
+          },
+          "placement_constraint": {
+            "title": "Placement constraint",
+            "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+            "type": "string",
+            "default": "hostname:UNIQUE"
+          },
+          "cpus": {
+            "title": "CPU count",
+            "description": "CPU requirements",
+            "type": "number",
+            "default":0.3
+          },
+          "mem": {
+            "title": "Memory size (MB)",
+            "description": "Mem requirements (in MB)",
+            "type": "integer",
+            "default":1024
+          },
+          "disk_type": {
+            "title": "Type of disk to use for persisting data",
+            "description": "ROOT or MOUNT",
+            "type": "string",
+            "default": "ROOT"
+          },
+          "disk_size": {
+            "title": "Dize of disk (MB)",
+            "type": "integer",
+            "default": 5120
+          }
+        },
+        "required":[
+          "cpus",
+          "mem",
+          "disk_type",
+          "disk_size"
+        ]
+      },
+      "influxdb": {
+        "description": "InfluxDB properties. This service is required to store Portworx cluster statistics by the Lightouse service",
+        "type": "object",
+        "properties": {
+          "placement_constraint": {
+            "title": "Placement constraint",
+            "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+            "type": "string",
+            "default": ""
+          },
+          "cpus": {
+            "title": "CPU count",
+            "description": "CPU requirements",
+            "type": "number",
+            "default":0.3
+          },
+          "mem": {
+            "title": "Memory size (MB)",
+            "description": "Mem requirements (in MB)",
+            "type": "integer",
+            "default": 1024
+          },
+          "disk_type": {
+            "title": "Type of disk to use for persisting data",
+            "description": "ROOT or MOUNT",
+            "type": "string",
+            "default": "ROOT"
+          },
+          "disk_size": {
+            "title": "Dize of disk (MB)",
+            "type": "integer",
+            "default": 1024
+          }
+        },
+        "required":[
+          "cpus",
+          "mem",
+          "disk_type",
+          "disk_size"
+        ]
+      },
+      "lighthouse": {
+        "description": "Lighthouse exposes the web UI for Portworx. Start this if you don't want to connect to the central Portworx Lighthouse",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "title": "Start Lighthouse",
+            "description": "Start the Lighthouse service. If this is disabled the influxdb service will also be disabled.",
+            "type": "boolean",
+            "default":true
+          },
+          "placement_constraint": {
+            "title": "Placement constraint",
+            "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+            "type": "string",
+            "default": ""
+          },
+          "cpus": {
+            "title": "CPU count",
+            "description": "CPU requirements",
+            "type": "number",
+            "default":0.3
+          },
+          "mem": {
+            "title": "Memory size (MB)",
+            "description": "Mem requirements (in MB)",
+            "type": "integer",
+            "default": 1024
+          },
+          "webui_port": {
+            "title": "WebUI Port",
+            "description": "",
+            "type": "integer",
+            "default": 8085
+          },
+          "company_name": {
+            "title": "Company Name",
+            "description": "Company Name to use for creating Lighthouse account",
+            "type": "string",
+            "default": "Portworx"
+          },
+          "admin_email": {
+            "title": "Administrator Email/Login",
+            "description": "Email to use for the Lighthouse account. Default password is admin and can be changed after first login. Used for resetting password and sending alerts.",
+            "type": "string",
+            "default": "portworx@yourcompany.com"
+          }
+        },
+        "required":[
+          "cpus",
+          "mem",
+          "webui_port",
+          "company_name",
+          "admin_email"
+        ]
+      }
+   }
+}

--- a/repo/packages/P/portworx/2/marathon.json.mustache
+++ b/repo/packages/P/portworx/2/marathon.json.mustache
@@ -1,0 +1,106 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M\" &&  ./portworx-scheduler/bin/portworx ./portworx-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
+  "env": {
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+    "PORTWORX_CLUSTER_NAME": "{{node.portworx_cluster}}",
+    "PORTWORX_IMAGE_NAME": "{{{node.portworx_image}}}",
+    "PORTWORX_OPTIONS": "{{{node.portworx_options}}}",
+    {{#etcd.enabled}}
+    "PORTWORX_KVDB": "etcd://etcd-proxy-0-start.{{service.name}}.mesos:2379",
+    {{/etcd.enabled}}
+    {{^etcd.enabled}}
+    "PORTWORX_KVDB": "{{node.kvdb_servers}}",
+    {{/etcd.enabled}}
+
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    {{#service.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.secret_name}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+
+    "ETCD_ENABLED": "{{etcd.enabled}}",
+    "ETCD_PLACEMENT": "{{etcd.placement_constraint}}",
+    "ETCD_CPUS": "{{etcd.cpus}}",
+    "ETCD_MEM": "{{etcd.mem}}",
+    "ETCD_DISK_TYPE": "{{etcd.disk_type}}",
+    "ETCD_DISK_SIZE": "{{etcd.disk_size}}",
+
+    "INFLUXDB_PLACEMENT": "{{influxdb.placement_constraint}}",
+    "INFLUXDB_CPUS": "{{influxdb.cpus}}",
+    "INFLUXDB_MEM": "{{influxdb.mem}}",
+    "INFLUXDB_DISK_TYPE": "{{influxdb.disk_type}}",
+    "INFLUXDB_DISK_SIZE": "{{influxdb.disk_size}}",
+
+    "LIGHTHOUSE_ENABLED": "{{lighthouse.enabled}}",
+    "LIGHTHOUSE_PLACEMENT": "{{lighthouse.placement_constraint}}",
+    "LIGHTHOUSE_CPUS": "{{lighthouse.cpus}}",
+    "LIGHTHOUSE_MEM": "{{lighthouse.mem}}",
+    "LIGHTHOUSE_WEBUI_PORT": "{{lighthouse.webui_port}}",
+    "LIGHTHOUSE_COMPANY_NAME": "{{lighthouse.company_name}}",
+    "LIGHTHOUSE_ADMIN_EMAIL": "{{lighthouse.admin_email}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 3
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx/2/package.json
+++ b/repo/packages/P/portworx/2/package.json
@@ -1,0 +1,30 @@
+{
+  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments.  Portworx enables containerized applications to be persistent, portable and protected.  For DCOS examples of Portworx, please see http://docs.portworx.com/run-with-mesosphere.html",
+  "framework": true,
+  "licenses": [
+    {
+      "name": "Apache 2.0 License",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ],
+  "maintainer": "support@portworx.com",
+  "minDcosReleaseVersion": "1.8",
+  "name": "portworx",
+  "packagingVersion": "3.0",
+  "postInstallNotes": "To see how Portorx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures,  please visit http://docs.portworx.com",
+  "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "preInstallNotes": "This DC/OS Service is currently in preview. Please visit https://docs.portworx.com/scheduler/mesosphere-dcos/install.html for detailed instructions. Default username/password for Lighthouse is portworx@yourcompany.com/admin",
+  "scm": "https://github.com/portworx/px-dev",
+  "tags": [
+    "portworx",
+    "storage",
+    "data",
+    "cloud",
+    "volume",
+    "encryption",
+    "s3",
+    "database"
+  ],
+  "version": "test-version",
+  "website": "http://www.portworx.com/"
+}

--- a/repo/packages/P/portworx/2/resource.json
+++ b/repo/packages/P/portworx/2/resource.json
@@ -1,0 +1,41 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u121-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.9.0-rc2-1.2.0-rc2-1.tar.gz",
+      "scheduler-zip": "https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/portworx-scheduler.zip",
+      "executor-zip": "https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/executor.zip",
+      "bootstrap-zip": "https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/bootstrap.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-small.png",
+    "icon-medium": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-medium.png",
+    "icon-large": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-large.png"
+  },
+  "cli":{
+    "binaries":{
+      "darwin":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"c97f99134f18bf58b4dfda1352de3bb82e35f13741ae4c0578037bb8add6b622" } ],
+          "kind":"executable",
+          "url":"https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/dcos-portworx-darwin"
+        }
+      },
+      "linux":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"c31f41a3cd7be9e9ad47e89841b8cf663b7c38d616539dfb0a528f3e6675ebd6" } ],
+          "kind":"executable",
+          "url":"https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/dcos-portworx-linux"
+        }
+      },
+      "windows":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"5edddaf236095eb03f46e64a6e69d7e717e2c7b3925a402a8c84208feae35406" } ],
+          "kind":"executable",
+          "url":"https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/dcos-portworx.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx test-version (automated commit)

Description:
Test

Changes since revision 1:
1 files added: [command.json]
0 files removed: []
4 files changed:

```
--- 1/config.json
+++ 2/config.json
@@ -1,66 +1,220 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+  "type": "object",
     "properties": {
-        "service":{
-            "type":"object",
-            "description": "DC/OS service configuration properties",
-            "properties":{
-                "name" : {
-                    "description":"Name of this service instance.",
-                    "type":"string",
-                    "default": "portworx"
-                }
-            }
-        },
-        "portworx":{
-	    "additionalProperties": false,
-            "description":  "PX configuration properties",
-            "properties": {
-               "framework-name": {
-               "description": "The name of the framework. Until this is configurable, please do not change this from it's default value.",
-               "type": "string",
-               "default": "portworx"
-               },
-               "cpus": {
-		      "default": 1.0,
-		      "description": "CPU shares to allocate to each Marathon instance.",
-		      "minimum": 0.0,
-		      "type": "number"
-	        },
-	       "mem": {
-			   "default": 2048.0,
-			   "description": "Memory (MB) to allocate to each Marathon task.",
-			   "minimum": 2048.0,
-			   "type": "number"
-		},
-		"instances": {
-			"default": 3,
-			"description": "Number of PX instances to run.",
-			"minimum": 3,
-			"type": "integer"
-			},
-                "cmdargs": {
-                    "description":  "Command args for Portworx.  See http://docs.portworx.com/run-with-docker.html#run-px",
-                    "type": "string",
-                    "default": "-a"
-                },
-                "headers_dir": {
-                    "description":  "Directory location for system headers.  Use /lib/modules for CoreOS, or /usr/src for other distros",
-                    "type": "string",
-                    "default": "/lib/modules"
-                },
-                "api_port": {
-                    "description":  "API access port",
-                    "type": "integer",
-                    "default": 9001
-                }
-            },
-            "required": [
-		"cmdargs",
-                "headers_dir",
-                "api_port",
-                "instances"
-            ]
-        }
-    }
+      "service": {
+        "type": "object",
+        "description": "DC/OS service configuration properties",
+        "properties": {
+          "name": {
+            "title": "Service name",
+            "description": "The name of the service instance",
+            "type": "string",
+            "default": "portworx"
+          },
+          "principal": {
+            "title": "Custom principal (optional)",
+            "description": "The principal for the service instance, or empty to use the default.",
+            "type": "string",
+            "default": ""
+          },
+          "secret_name": {
+            "title": "Credential secret name (optional)",
+            "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+            "type": "string",
+            "default": ""
+          }
+        },
+        "required":[
+          "name"
+        ]
+      },
+      "node": {
+        "description": "Portworx Node properties",
+        "type": "object",
+        "properties": {
+          "portworx_cluster": {
+            "title": "Portworx Cluster Name",
+            "type": "string",
+            "default":"portworx-dcos"
+          },
+          "portworx_image": {
+            "title": "Portworx Image name",
+            "type": "string",
+            "default":"px-dev:latest"
+          },
+          "portworx_options": {
+            "title": "Portworx Options",
+            "type": "string",
+            "default":"-a"
+          },
+          "kvdb_servers": {
+            "title":"KVDB servers",
+            "description": "Comma seperated IP:PORT entries for the key value database (etcd or consul). If the etcd server is started using the pacakge this will be ignored",
+            "type": "string",
+            "default": ""
+          },
+          "count": {
+            "title": "Node count",
+            "description": "Number of Portworx nodes to run",
+            "type": "integer",
+            "default":3
+          },
+          "placement_constraint": {
+            "title": "Placement constraint",
+            "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+            "type": "string",
+            "default": "hostname:UNIQUE"
+          }
+        },
+        "required":[
+          "count",
+          "portworx_cluster",
+          "portworx_image",
+          "portworx_options"
+        ]
+      },
+      "etcd": {
+        "description": "Start a 3 node etcd cluster. Required for Portworx if you don't have either etcd or consul already running",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "title": "Start etcd",
+            "description": "If disabled, please enter the external etcd server IP on the service tab.",
+            "type": "boolean",
+            "default":true
+          },
+          "placement_constraint": {
+            "title": "Placement constraint",
+            "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+            "type": "string",
+            "default": "hostname:UNIQUE"
+          },
+          "cpus": {
+            "title": "CPU count",
+            "description": "CPU requirements",
+            "type": "number",
+            "default":0.3
+          },
+          "mem": {
+            "title": "Memory size (MB)",
+            "description": "Mem requirements (in MB)",
+            "type": "integer",
+            "default":1024
+          },
+          "disk_type": {
+            "title": "Type of disk to use for persisting data",
+            "description": "ROOT or MOUNT",
+            "type": "string",
+            "default": "ROOT"
+          },
+          "disk_size": {
+            "title": "Dize of disk (MB)",
+            "type": "integer",
+            "default": 5120
+          }
+        },
+        "required":[
+          "cpus",
+          "mem",
+          "disk_type",
+          "disk_size"
+        ]
+      },
+      "influxdb": {
+        "description": "InfluxDB properties. This service is required to store Portworx cluster statistics by the Lightouse service",
+        "type": "object",
+        "properties": {
+          "placement_constraint": {
+            "title": "Placement constraint",
+            "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+            "type": "string",
+            "default": ""
+          },
+          "cpus": {
+            "title": "CPU count",
+            "description": "CPU requirements",
+            "type": "number",
+            "default":0.3
+          },
+          "mem": {
+            "title": "Memory size (MB)",
+            "description": "Mem requirements (in MB)",
+            "type": "integer",
+            "default": 1024
+          },
+          "disk_type": {
+            "title": "Type of disk to use for persisting data",
+            "description": "ROOT or MOUNT",
+            "type": "string",
+            "default": "ROOT"
+          },
+          "disk_size": {
+            "title": "Dize of disk (MB)",
+            "type": "integer",
+            "default": 1024
+          }
+        },
+        "required":[
+          "cpus",
+          "mem",
+          "disk_type",
+          "disk_size"
+        ]
+      },
+      "lighthouse": {
+        "description": "Lighthouse exposes the web UI for Portworx. Start this if you don't want to connect to the central Portworx Lighthouse",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "title": "Start Lighthouse",
+            "description": "Start the Lighthouse service. If this is disabled the influxdb service will also be disabled.",
+            "type": "boolean",
+            "default":true
+          },
+          "placement_constraint": {
+            "title": "Placement constraint",
+            "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+            "type": "string",
+            "default": ""
+          },
+          "cpus": {
+            "title": "CPU count",
+            "description": "CPU requirements",
+            "type": "number",
+            "default":0.3
+          },
+          "mem": {
+            "title": "Memory size (MB)",
+            "description": "Mem requirements (in MB)",
+            "type": "integer",
+            "default": 1024
+          },
+          "webui_port": {
+            "title": "WebUI Port",
+            "description": "",
+            "type": "integer",
+            "default": 8085
+          },
+          "company_name": {
+            "title": "Company Name",
+            "description": "Company Name to use for creating Lighthouse account",
+            "type": "string",
+            "default": "Portworx"
+          },
+          "admin_email": {
+            "title": "Administrator Email/Login",
+            "description": "Email to use for the Lighthouse account. Default password is admin and can be changed after first login. Used for resetting password and sending alerts.",
+            "type": "string",
+            "default": "portworx@yourcompany.com"
+          }
+        },
+        "required":[
+          "cpus",
+          "mem",
+          "webui_port",
+          "company_name",
+          "admin_email"
+        ]
+      }
+   }
 }
--- 1/marathon.json.mustache
+++ 2/marathon.json.mustache
@@ -1,66 +1,106 @@
 {
-  "id": "{{portworx.framework-name}}",
-  "cpus": {{portworx.cpus}},
-  "mem": {{portworx.mem}},
-  "instances": {{portworx.instances}},
-  "constraints": [
-        ["hostname", "UNIQUE"]
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M\" &&  ./portworx-scheduler/bin/portworx ./portworx-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
+  "env": {
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+    "PORTWORX_CLUSTER_NAME": "{{node.portworx_cluster}}",
+    "PORTWORX_IMAGE_NAME": "{{{node.portworx_image}}}",
+    "PORTWORX_OPTIONS": "{{{node.portworx_options}}}",
+    {{#etcd.enabled}}
+    "PORTWORX_KVDB": "etcd://etcd-proxy-0-start.{{service.name}}.mesos:2379",
+    {{/etcd.enabled}}
+    {{^etcd.enabled}}
+    "PORTWORX_KVDB": "{{node.kvdb_servers}}",
+    {{/etcd.enabled}}
+
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    {{#service.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.secret_name}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+
+    "ETCD_ENABLED": "{{etcd.enabled}}",
+    "ETCD_PLACEMENT": "{{etcd.placement_constraint}}",
+    "ETCD_CPUS": "{{etcd.cpus}}",
+    "ETCD_MEM": "{{etcd.mem}}",
+    "ETCD_DISK_TYPE": "{{etcd.disk_type}}",
+    "ETCD_DISK_SIZE": "{{etcd.disk_size}}",
+
+    "INFLUXDB_PLACEMENT": "{{influxdb.placement_constraint}}",
+    "INFLUXDB_CPUS": "{{influxdb.cpus}}",
+    "INFLUXDB_MEM": "{{influxdb.mem}}",
+    "INFLUXDB_DISK_TYPE": "{{influxdb.disk_type}}",
+    "INFLUXDB_DISK_SIZE": "{{influxdb.disk_size}}",
+
+    "LIGHTHOUSE_ENABLED": "{{lighthouse.enabled}}",
+    "LIGHTHOUSE_PLACEMENT": "{{lighthouse.placement_constraint}}",
+    "LIGHTHOUSE_CPUS": "{{lighthouse.cpus}}",
+    "LIGHTHOUSE_MEM": "{{lighthouse.mem}}",
+    "LIGHTHOUSE_WEBUI_PORT": "{{lighthouse.webui_port}}",
+    "LIGHTHOUSE_COMPANY_NAME": "{{lighthouse.company_name}}",
+    "LIGHTHOUSE_ADMIN_EMAIL": "{{lighthouse.admin_email}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
   ],
-  "container": {
-        "type": "DOCKER",
-        "docker": {
-            "image": "{{resource.assets.container.docker.portworx-docker}}",
-            "forcePullImage": true,
-            "network": "HOST",
-            "privileged": true,
-            "parameters": [
-			{
-			    "key": "volume",
-			    "value": "/run/docker/plugins:/run/docker/plugins"
-			},
-			{
-			    "key": "volume",
-			    "value": "/etc/pwx:/etc/pwx"
-			},
-			{
-			    "key": "volume",
-			    "value": "/var/lib/osd:/var/lib/osd:shared"
-			},
-			{
-			    "key": "volume",
-			    "value": "/dev:/dev"
-			},
-			{
-			    "key": "volume",
-			    "value": "/opt/pwx/bin:/export_bin"
-			},
-			{
-			    "key": "volume",
-			    "value": "/var/run/docker.sock:/var/run/docker.sock"
-			},
-			{
-			    "key": "volume",
-			    "value": "/var/cores:/var/cores"
-			},
-			{
-			    "key": "volume",
-			    "value": "{{portworx.headers_dir}}:{{portworx.headers_dir}}"
-			}
-	      ]
-	}
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 3
     },
-    "args": [
-        "--name pxcluster.mesos",
-        "{{portworx.cmdargs}}"
-    ],
-    "healthChecks": [
     {
-        "protocol": "HTTP",
-        "port": {{portworx.api_port}},
-        "path": "/status",
-        "gracePeriodSeconds": 300,
-        "intervalSeconds": 60,
-        "timeoutSeconds": 20,
-        "maxConsecutiveFailures": 3
-    }]
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
 }
--- 1/package.json
+++ 2/package.json
@@ -1,13 +1,20 @@
 {
-  "packagingVersion": "3.0",
+  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments.  Portworx enables containerized applications to be persistent, portable and protected.  For DCOS examples of Portworx, please see http://docs.portworx.com/run-with-mesosphere.html",
+  "framework": true,
+  "licenses": [
+    {
+      "name": "Apache 2.0 License",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ],
+  "maintainer": "support@portworx.com",
   "minDcosReleaseVersion": "1.8",
   "name": "portworx",
-  "version": "1.1.6-3.0",
+  "packagingVersion": "3.0",
+  "postInstallNotes": "To see how Portorx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures,  please visit http://docs.portworx.com",
+  "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "preInstallNotes": "This DC/OS Service is currently in preview. Please visit https://docs.portworx.com/scheduler/mesosphere-dcos/install.html for detailed instructions. Default username/password for Lighthouse is portworx@yourcompany.com/admin",
   "scm": "https://github.com/portworx/px-dev",
-  "maintainer": "support@portworx.com",
-  "website": "http://www.portworx.com/",
-  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments.  Portworx enables containerized applications to be persistent, portable and protected.  For DCOS examples of Portworx, please see https://github.com/dcos/examples/tree/master/1.8/portworx and http://docs.portworx.com/run-with-mesosphere.html",
-  "framework": true,
   "tags": [
     "portworx",
     "storage",
@@ -18,13 +25,6 @@
     "s3",
     "database"
   ],
-  "preInstallNotes": "This DC/OS Service is currently in preview. Please visit http://docs.portworx.com/run-with-mesosphere.html for detailed instructions",
- "postInstallNotes": "To see how Portorx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures,  please visit http://docs.portworx.com",
- "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
-  "licenses": [
-    {
-      "name": "Apache 2.0 License",
-      "url": "https://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ]
+  "version": "test-version",
+  "website": "http://www.portworx.com/"
 }
--- 1/resource.json
+++ 2/resource.json
@@ -1,13 +1,40 @@
 {
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u121-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.9.0-rc2-1.2.0-rc2-1.tar.gz",
+      "scheduler-zip": "https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/portworx-scheduler.zip",
+      "executor-zip": "https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/executor.zip",
+      "bootstrap-zip": "https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/bootstrap.zip"
+    }
+  },
   "images": {
     "icon-small": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-small.png",
     "icon-medium": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-medium.png",
     "icon-large": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-large.png"
   },
-  "assets": {
-    "container": {
-      "docker": {
-        "portworx-docker": "portworx/px-dev:dcos-1.8"
+  "cli":{
+    "binaries":{
+      "darwin":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"c97f99134f18bf58b4dfda1352de3bb82e35f13741ae4c0578037bb8add6b622" } ],
+          "kind":"executable",
+          "url":"https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/dcos-portworx-darwin"
+        }
+      },
+      "linux":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"c31f41a3cd7be9e9ad47e89841b8cf663b7c38d616539dfb0a528f3e6675ebd6" } ],
+          "kind":"executable",
+          "url":"https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/dcos-portworx-linux"
+        }
+      },
+      "windows":{
+        "x86-64":{
+          "contentHash":[ { "algo":"sha256", "value":"5edddaf236095eb03f46e64a6e69d7e717e2c7b3925a402a8c84208feae35406" } ],
+          "kind":"executable",
+          "url":"https://disrani-dcos.s3.amazonaws.com/portworx/assets/test-version/dcos-portworx.exe"
+        }
       }
     }
   }
```
