### PR TITLE
Release portworx-hadoop 1.1-2.6.0-bf399c5 (automated commit)



### DIFF
--- a/repo/packages/P/portworx-hadoop/0/config.json
+++ b/repo/packages/P/portworx-hadoop/0/config.json
@@ -1,0 +1,426 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "portworx-hadoop"
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "user": {
+          "type": "string",
+          "description": "The linux user used to run the scheduler and all executors.",
+          "default": "root"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "default": "V0"
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "deploy_strategy": {
+          "description": "HDFS deployment strategy. [parallel, serial]",
+          "type": "string",
+          "default": "parallel",
+          "enum": [
+            "parallel",
+            "serial"
+          ]
+        },
+        "update_strategy": {
+          "description": "HDFS update strategy. [parallel, serial]",
+          "type": "string",
+          "default": "serial",
+          "enum": [
+            "parallel",
+            "serial"
+          ]
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        },
+        "tls": {
+          "type": "object",
+          "description": "TLS configuration properties.",
+          "properties": {
+            "enabled": {
+              "description": "Enable TLS support (requires Strict mode).",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "kerberos": {
+          "type": "object",
+          "description": "Kerberos configuration properties.",
+          "properties": {
+            "enabled": {
+              "description": "Enable kerberos authentication.",
+              "type": "boolean",
+              "default": false
+            },
+            "keytabs_uri": {
+              "type": "string",
+              "description": "The URI from which Keytabs tar.gz can be downloaded. Only relevant when secure_mode is enabled.",
+              "default": ""
+            },
+            "krb5_conf_uri": {
+              "type": "string",
+              "description": "The URI of the krb5.conf file.  This file will be downloaded and used by each HDFS task."
+            },
+            "primary": {
+              "type": "string",
+              "description": "The Kerberos primary used by HDFS tasks.  The full principal will be <service.kerberos.primary>/<mesos_dns_address>@<service.kerberos.realm>",
+              "default": "hdfs"
+            },
+            "primary_http": {
+              "type": "string",
+              "description": "The Kerberos primary used by the HTTP server running on HDFS tasks.  See <service.kerberos.primary>.",
+              "default": "HTTP"
+            },
+            "realm": {
+              "type": "string",
+              "description": "The Kerberos realm used to render the principal of HDFS tasks.",
+              "default": "LOCAL"
+            }
+          }
+        }
+      }
+    },
+    "journal_node": {
+      "description": "HDFS configuration properties.",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Journal node CPU requirement",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "description": "Journal node memory requirement",
+          "type": "number",
+          "default": 2048
+        },
+        "disk": {
+          "description": "Journal node disk size requirement in MB",
+          "type": "number",
+          "default": 5000
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "HDFSJournalVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "enable_readiness_check": {
+          "description": "Determines whether to enable readiness checks for Journal Nodes.",
+          "type": "boolean",
+          "default": true
+        },
+        "lagging_tx_count": {
+          "description": "The number of transactions that this JournalNode is lagging",
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "portworx_volume_name"
+      ]
+    },
+    "name_node": {
+      "description": "HDFS configuration properties.",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Name node CPU requirement",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "description": "Name node memory requirement",
+          "type": "number",
+          "default": 2048
+        },
+        "disk": {
+          "description": "Name node disk size requirement in MB",
+          "type": "number",
+          "default": 5000
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "HDFSNameVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "portworx_volume_name"
+      ]
+    },
+    "zkfc_node": {
+      "description": "HDFS configuration properties.",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "ZKFC node CPU requirement",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "description": "ZKFC node memory requirement",
+          "type": "number",
+          "default": 2048
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "data_node": {
+      "description": "HDFS configuration properties.",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Data node count requirement",
+          "type": "number",
+          "default": 3
+        },
+        "cpus": {
+          "description": "Data node CPU requirement",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "description": "Data node memory requirement",
+          "type": "number",
+          "default": 2048
+        },
+        "disk": {
+          "description": "Data node disk size requirement in MB",
+          "type": "number",
+          "default": 5000
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "HDFSDataVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "portworx_volume_name"
+      ]
+    },
+    "yarn_node": {
+      "description": "Yarn configuration properties.",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Yarn node CPU requirement",
+          "type": "number",
+          "default": 2
+        },
+        "mem": {
+          "description": "Yarn node memory requirement",
+          "type": "number",
+          "default": 2048
+        },
+        "scheduler_min_allocation_mb": {
+          "description": "Minimum limit of memory to allocate to each container request at the Resource Manager.",
+          "type": "number",
+          "default": 128
+        },
+        "scheduler_max_allocation_mb": {
+          "description": "Maximum limit of memory to allocate to each container request at the Resource Manager.",
+          "type": "number",
+          "default": 2048
+        },
+        "scheduler_min_allocation_vcores": {
+          "description": "The minimum allocation for every container request at the RM, in terms of virtual CPU cores.",
+          "type": "number",
+          "default": 1
+        },
+        "scheduler_max_allocation_vcores": {
+          "description": "The maximum allocation for every container request at the RM, in terms of virtual CPU cores",
+          "type": "number",
+          "default": 2
+        },
+        "nodemanager_memory_mb": {
+          "description": "Physical memory, in MB, to be made available to running containers.",
+          "type": "number",
+          "default": 4096
+        },
+        "nodemanager_cpu_vcores": {
+          "description": "Number of CPU cores that can be allocated for containers.",
+          "type": "number",
+          "default": 4
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "scheduler_min_allocation_mb",
+        "scheduler_max_allocation_mb",
+        "scheduler_min_allocation_vcores",
+        "scheduler_max_allocation_vcores",
+        "nodemanager_memory_mb",
+        "nodemanager_cpu_vcores"
+      ]
+    },
+    "hdfs": {
+      "type": "object",
+      "description": "HDFS File System configuration options",
+      "properties": {
+        "administrators": {
+          "type": "string",
+          "description": "Administrators for the HDFS cluster",
+          "default": "core,centos,azureuser"
+        },
+        "name_node_rpc_port": {
+          "type": "integer",
+          "description": "The RPC port for HDFS Name Nodes.",
+          "default": 10001
+        },
+        "name_node_http_port": {
+          "type": "integer",
+          "description": "The HTTP port for HDFS Name Nodes. ",
+          "default": 10002
+        },
+        "zkfc_port": {
+          "type": "integer",
+          "description": "The port for ZKFC Nodes. ",
+          "default": 8019
+        },
+        "journal_node_rpc_port": {
+          "type": "integer",
+          "description": "The RPC port used by Journal Nodes.",
+          "default": 8485
+        },
+        "journal_node_http_port": {
+          "type": "integer",
+          "description": "The HTTP port used by Journal Nodes.",
+          "default": 8480
+        },
+        "data_node_rpc_port": {
+          "type": "integer",
+          "description": "The RPC port used by Data Nodes.",
+          "default": 10003
+        },
+        "data_node_http_port": {
+          "type": "integer",
+          "description": "The HTTP port used by Data Nodes.",
+          "default": 10004
+        },
+        "data_node_ipc_port": {
+          "type": "integer",
+          "description": "The IPS port used by Data Nodes.",
+          "default": 10005
+        },
+        "permissions_enabled": {
+          "type": "boolean",
+          "description": "If true, permissions checking is enabled",
+          "default": false
+        },
+        "name_node_heartbeat_recheck_interval": {
+          "type": "integer",
+          "description": "This time decides the interval to check for expired datanodes.",
+          "default": 60000
+        },
+        "compress_image": {
+          "type": "boolean",
+          "description": "If true, the File System image will be compressed.",
+          "default": true
+        },
+        "image_compression_codec": {
+          "type": "string",
+          "description": "The image compression codec for the File System image.",
+          "default": "org.apache.hadoop.io.compress.SnappyCodec"
+        },
+        "hadoop_root_logger": {
+          "type": "string",
+          "description": "",
+          "default": "INFO,console"
+        },
+        "ipc_client_connect_max_retries": {
+          "type": "integer",
+          "description": "Indicates the number of retries a client will make to establish a server connection.",
+          "default": 300
+        }
+      },
+      "required": [
+        "name_node_rpc_port",
+        "name_node_http_port",
+        "journal_node_rpc_port",
+        "journal_node_http_port",
+        "data_node_rpc_port",
+        "data_node_http_port",
+        "data_node_ipc_port",
+        "permissions_enabled",
+        "name_node_heartbeat_recheck_interval",
+        "compress_image",
+        "image_compression_codec"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx-hadoop/0/marathon.json.mustache
+++ b/repo/packages/P/portworx-hadoop/0/marathon.json.mustache
@@ -1,0 +1,178 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./hdfs-scheduler/bin/hdfs ./hdfs-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "HDFS_VERSION": "hadoop-2.6.0-cdh5.11.0",
+    "JRE_VERSION": "jre1.8.0_131",
+    "TASKCFG_ALL_JRE_VERSION": "jre1.8.0_131",
+    "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
+    "UPDATE_STRATEGY": "{{service.update_strategy}}",
+    "SERVICE_PRINCIPAL": "{{service.service_account}}",
+    "JOURNAL_CPUS": "{{journal_node.cpus}}",
+    "JOURNAL_MEM": "{{journal_node.mem}}",
+    "JOURNAL_DISK": "{{journal_node.disk}}",
+    "JOURNAL_LAGGING_TX_COUNT": "{{journal_node.lagging_tx_count}}",
+    "JOURNAL_DISK_DOCKER_VOLUME_NAME": "{{{journal_node.portworx_volume_name}}}",
+    "JOURNAL_DISK_DOCKER_DRIVER_OPTIONS": "{{{journal_node.portworx_volume_options}}}",
+    "NAME_CPUS": "{{name_node.cpus}}",
+    "NAME_MEM": "{{name_node.mem}}",
+    "NAME_DISK": "{{name_node.disk}}",
+    "NAME_DISK_DOCKER_VOLUME_NAME": "{{{name_node.portworx_volume_name}}}",
+    "NAME_DISK_DOCKER_DRIVER_OPTIONS": "{{{name_node.portworx_volume_options}}}",
+    "ZKFC_CPUS": "{{zkfc_node.cpus}}",
+    "ZKFC_MEM": "{{zkfc_node.mem}}",
+    "DATA_COUNT": "{{data_node.count}}",
+    "DATA_CPUS": "{{data_node.cpus}}",
+    "DATA_MEM": "{{data_node.mem}}",
+    "DATA_DISK": "{{data_node.disk}}",
+    "DATA_DISK_DOCKER_VOLUME_NAME": "{{{data_node.portworx_volume_name}}}",
+    "DATA_DISK_DOCKER_DRIVER_OPTIONS": "{{{data_node.portworx_volume_options}}}",
+    "YARN_CPUS": "{{yarn_node.cpus}}",
+    "YARN_MEM": "{{yarn_node.mem}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "HDFS_URI": "{{resource.assets.uris.hdfs-tar-gz}}",
+    "HDFS_BIN_URI": "{{resource.assets.uris.hdfs-bin-tar-gz}}",
+    "HDFS_JAVA_URI": "{{resource.assets.uris.hdfs-jre-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service_account_secret}}
+
+    {{#service.tls.enabled}}
+    "TLS_ENABLED": "{{service.tls.enabled}}",
+    "TASKCFG_ALL_TLS_ENABLED": "{{service.tls.enabled}}",
+    {{/service.tls.enabled}}
+
+    {{#journal_node.enable_readiness_check}}
+    "JOURNAL_READINESS_CHECK_ENABLED": "{{journal_node.enable_readiness_check}}",
+    "TASKCFG_ALL_JOURNAL_READINESS_CHECK_ENABLED": "{{journal_node.enable_readiness_check}}",
+    {{/journal_node.enable_readiness_check}}
+
+
+    {{#service.kerberos.enabled}}
+    "KEYTABS_URI": "{{service.kerberos.keytabs_uri}}",
+    "KRB5_CONF_URI": "{{service.kerberos.krb5_conf_uri}}",
+    "TASKCFG_ALL_SECURE_MODE": "{{service.kerberos.enabled}}",
+    "TASKCFG_ALL_KERBEROS_PRIMARY": "{{service.kerberos.primary}}",
+    "TASKCFG_ALL_KERBEROS_PRIMARY_HTTP": "{{service.kerberos.primary_http}}",
+    "TASKCFG_ALL_KERBEROS_REALM": "{{service.kerberos.realm}}",
+    {{/service.kerberos.enabled}}
+    "TASKCFG_ALL_ADMINISTRATORS": "{{hdfs.administrators}}",
+    "TASKCFG_ALL_NAME_NODE_RPC_PORT":"{{hdfs.name_node_rpc_port}}",
+    "TASKCFG_ALL_NAME_NODE_HTTP_PORT":"{{hdfs.name_node_http_port}}",
+    "TASKCFG_ALL_ZKFC_PORT": "{{hdfs.zkfc_port}}",
+    "TASKCFG_ALL_JOURNAL_NODE_RPC_PORT":"{{hdfs.journal_node_rpc_port}}",
+    "TASKCFG_ALL_JOURNAL_NODE_HTTP_PORT":"{{hdfs.journal_node_http_port}}",
+    "TASKCFG_ALL_DATA_NODE_RPC_PORT":"{{hdfs.data_node_rpc_port}}",
+    "TASKCFG_ALL_DATA_NODE_HTTP_PORT":"{{hdfs.data_node_http_port}}",
+    "TASKCFG_ALL_DATA_NODE_IPC_PORT":"{{hdfs.data_node_ipc_port}}",
+    "TASKCFG_ALL_DATA_NODE_BALANCE_BANDWIDTH_PER_SEC":"41943040",
+    "TASKCFG_ALL_NAME_NODE_SAFEMODE_THRESHOLD_PCT":"0.9",
+    "TASKCFG_ALL_DATA_NODE_HANDLER_COUNT":"10",
+    "TASKCFG_ALL_NAME_NODE_HANDLER_COUNT":"20",
+    "TASKCFG_ALL_PERMISSIONS_ENABLED":"{{hdfs.permissions_enabled}}",
+    "TASKCFG_ALL_NAME_NODE_HEARTBEAT_RECHECK_INTERVAL":"{{hdfs.name_node_heartbeat_recheck_interval}}",
+    "TASKCFG_ALL_IMAGE_COMPRESS":"{{hdfs.compress_image}}",
+    "TASKCFG_ALL_IMAGE_COMPRESSION_CODEC":"{{hdfs.image_compression_codec}}",
+    "TASKCFG_ALL_NAME_NODE_INVALIDATE_WORK_PCT_PER_ITERATION":"0.95",
+    "TASKCFG_ALL_NAME_NODE_REPLICATION_MIN":"3",
+    "TASKCFG_ALL_NAME_NODE_REPLICATION_WORK_MULTIPLIER_PER_ITERATION":"4",
+    "TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT":"true",
+    "TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_PATH":"dn_socket",
+    "TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE":"1000",
+    "TASKCFG_ALL_CLIENT_READ_SHORTCIRCUIT_STREAMS_CACHE_SIZE_EXPIRY_MS":"1000",
+    "TASKCFG_ALL_NAME_NODE_DATA_NODE_REGISTRATION_IP_HOSTNAME_CHECK": "false",
+    "TASKCFG_ALL_HA_FENCING_METHODS": "shell(/bin/true)",
+    "TASKCFG_ALL_HA_AUTOMATIC_FAILURE": "true",
+    "TASKCFG_ALL_CLIENT_FAILOVER_PROXY_PROVIDER_HDFS": "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
+    "TASKCFG_ALL_HADOOP_PROXYUSER_HUE_HOSTS": "*",
+    "TASKCFG_ALL_HADOOP_PROXYUSER_HUE_GROUPS": "*",
+    "TASKCFG_ALL_HADOOP_PROXYUSER_ROOT_HOSTS": "*",
+    "TASKCFG_ALL_HADOOP_PROXYUSER_ROOT_GROUPS": "*",
+    "TASKCFG_ALL_HADOOP_PROXYUSER_HTTPFS_GROUPS": "*",
+    "TASKCFG_ALL_HADOOP_PROXYUSER_HTTPFS_HOSTS": "*",
+    "TASKCFG_ALL_HADOOP_ROOT_LOGGER": "{{hdfs.hadoop_root_logger}}",
+    "TASKCFG_ALL_IPC_CLIENT_CONNECT_MAX_RETRIES": "{{hdfs.ipc_client_connect_max_retries}}",
+    "TASKCFG_ALL_TASK_USER": "{{service.user}}",
+    "TASKCFG_ALL_YARN_NODE_SCHED_MIN_ALLOC_MB": "{{yarn_node.scheduler_min_allocation_mb}}",
+    "TASKCFG_ALL_YARN_NODE_SCHED_MAX_ALLOC_MB": "{{yarn_node.scheduler_max_allocation_mb}}",
+    "TASKCFG_ALL_YARN_NODE_SCHED_MIN_ALLOC_VCORES": "{{yarn_node.scheduler_min_allocation_vcores}}",
+    "TASKCFG_ALL_YARN_NODE_SCHED_MAX_ALLOC_VCORES": "{{yarn_node.scheduler_max_allocation_vcores}}",
+    "TASKCFG_ALL_YARN_NODE_MANAGER_MEM_MB": "{{yarn_node.nodemanager_memory_mb}}",
+    "TASKCFG_ALL_YARN_NODE_MANAGER_CPU_VCORES": "{{yarn_node.nodemanager_cpu_vcores}}",
+    "CONFIG_TEMPLATE_PATH": "hdfs-scheduler"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    {{#service.kerberos.enabled}}
+    "{{service.kerberos.krb5_conf_uri}}",
+    {{/service.kerberos.enabled}}
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-hadoop/0/package.json
+++ b/repo/packages/P/portworx-hadoop/0/package.json
@@ -1,0 +1,18 @@
+{
+  "description": "Apache Hadoop",
+  "framework": true,
+  "maintainer": "support@portworx.com",
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx-hadoop",
+  "packagingVersion": "4.0",
+  "postInstallNotes": "DC/OS Apache HDFS Service is being installed.\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/hadoop-hdfs.html",
+  "postUninstallNotes": "DC/OS Apache HDFS Service is being uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
+  "preInstallNotes": "Default configuration requires 5 agent nodes each with: CPU: 0.9 | Memory: 6144MB\n\nMore specifically, each instance type requires:\n\nJournal node: 3 instances | 0.3 CPU | 2048 MB MEM\n\nName node: 2 instances | 0.3 CPU | 2048 MB MEM\n\nZKFC node: 2 instances | 0.3 CPU | 2048 MB MEM\n\nData node: 3 instances | 0.3 CPU | 2048 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
+  "selected": false,
+  "tags": [
+    "hdfs",
+    "hadoop",
+    "portworx"
+  ],
+  "version": "1.1-2.6.0-bf399c5"
+}

--- a/repo/packages/P/portworx-hadoop/0/resource.json
+++ b/repo/packages/P/portworx-hadoop/0/resource.json
@@ -1,0 +1,59 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64-jce-unlimited.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "hdfs-tar-gz": "https://downloads.mesosphere.com/hdfs/assets/hadoop-2.6.0-cdh5.11.0.tar.gz",
+      "hdfs-bin-tar-gz": "https://s3-us-west-2.amazonaws.com/mrbrowning-dev/hdfs-bin.tar.gz",
+      "hdfs-jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64-jce-unlimited.tar.gz",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-hadoop/assets/1.1-2.6.0-bf399c5/bootstrap.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-hadoop/assets/1.1-2.6.0-bf399c5/hdfs-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-hadoop/assets/1.1-2.6.0-bf399c5/executor.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/hdfs/assets/icon-service-hdfs-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/hdfs/assets/icon-service-hdfs-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/hdfs/assets/icon-service-hdfs-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "ed5b73206500159484c31f2b31b262f3a6297b92bd23277ee3b38a4b7cd1f93c"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-hadoop/assets/1.1-2.6.0-bf399c5/dcos-portworx-hadoop-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "e39c15f7733d75096a21c8b89c928cac399013708e6a9d75c691d5348e910bfa"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-hadoop/assets/1.1-2.6.0-bf399c5/dcos-portworx-hadoop-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "d6243ab206bbc487ce6a4722aa959c60d3c377af46641e80c81ae987456d1d01"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-hadoop/assets/1.1-2.6.0-bf399c5/dcos-portworx-hadoop.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx-hadoop 1.1-2.6.0-bf399c5 (automated commit)

Changes since revision -1:
4 files added: [resource.json, package.json, marathon.json.mustache, config.json]
0 files removed: []
0 files changed:

```
```
