### PR TITLE
Release portworx 1.1-1.2.11.5-b02c112 (automated commit)



### DIFF
--- a/repo/packages/P/portworx/4/config.json
+++ b/repo/packages/P/portworx/4/config.json
@@ -1,0 +1,282 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "portworx"
+        },
+        "user": {
+          "description": "The user that runs the Portworx tasks.",
+          "type": "string",
+          "default": "root"
+        },
+        "principal": {
+          "title": "Custom principal (optional)",
+          "description": "The principal for the service instance, or empty to use the default.",
+          "type": "string",
+          "default": ""
+        },
+        "secret_name": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "node": {
+      "description": "Portworx Node properties",
+      "type": "object",
+      "properties": {
+        "portworx_cluster": {
+          "title": "Portworx Cluster Name",
+          "type": "string",
+          "default": "portworx-dcos"
+        },
+        "portworx_image": {
+          "title": "Portworx Image name",
+          "type": "string",
+          "default": "portworx/px-enterprise:1.2.11.5"
+        },
+        "portworx_options": {
+          "title": "Portworx Options",
+          "type": "string",
+          "default": "-a"
+        },
+        "kvdb_servers": {
+          "title": "KVDB servers",
+          "description": "Comma seperated IP:PORT entries for the key value database (etcd or consul). If the etcd server is started using the pacakge this will be ignored",
+          "type": "string",
+          "default": ""
+        },
+        "container_parameters": {
+          "title": "Container parameters",
+          "type": "string",
+          "description": "Any additional paramters to pass in to the Portworx container. For example environment variables can be passed in using \"-e\"",
+          "default": ""
+        },
+        "count": {
+          "title": "Node count",
+          "description": "Number of Portworx nodes to run",
+          "type": "integer",
+          "default": 3
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        }
+      },
+      "required": [
+        "count",
+        "portworx_cluster",
+        "portworx_image",
+        "portworx_options"
+      ]
+    },
+    "etcd": {
+      "description": "Start a 3 node etcd cluster. Required for Portworx if you don't have either etcd or consul already running. For Production it is recommended to run an etcd cluster outside your DC/OS cluster.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Start etcd",
+          "description": "If disabled, please enter the external etcd server IP on the service tab.",
+          "type": "boolean",
+          "default": false
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        },
+        "image": {
+          "title": "Etcd Image name",
+          "type": "string",
+          "default": "mesosphere/etcd-mesos:latest"
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "CPU requirements",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk_type": {
+          "title": "Type of disk to use for persisting data",
+          "description": "ROOT or MOUNT",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "disk_size": {
+          "title": "Dize of disk (MB)",
+          "type": "integer",
+          "default": 5120
+        },
+        "node_advertise_port": {
+          "title": "Cluster Node advertise port",
+          "description": "Port on which the etcd cluster nodes will listen",
+          "type": "integer",
+          "default": 1026
+        },
+        "node_peer_port": {
+          "title": "Cluster Node peer port",
+          "description": "Port on which the etcd cluster nodes will communicate with each other",
+          "type": "integer",
+          "default": 1027
+        },
+        "proxy_advertise_port": {
+          "title": "Cluster Proxy advertise port",
+          "description": "Port on which the etcd proxy will listen",
+          "type": "integer",
+          "default": 2379
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk_type",
+        "disk_size",
+        "node_advertise_port",
+        "node_peer_port",
+        "proxy_advertise_port",
+        "image"
+      ]
+    },
+    "influxdb": {
+      "description": "InfluxDB properties. This service is required to store Portworx cluster statistics by the Lightouse service",
+      "type": "object",
+      "properties": {
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "CPU requirements",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk_type": {
+          "title": "Type of disk to use for persisting data",
+          "description": "ROOT or MOUNT",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "disk_size": {
+          "title": "Dize of disk (MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "image": {
+          "title": "Influxdb Image name",
+          "type": "string",
+          "default": "influxdb:latest"
+        },
+        "listen_port": {
+          "title": "The port on which influxdb listens for incoming requests",
+          "type": "integer",
+          "default": 8086
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk_type",
+        "disk_size",
+        "image",
+        "listen_port"
+      ]
+    },
+    "lighthouse": {
+      "description": "Lighthouse exposes the web UI for Portworx. Start this if you don't want to connect to the central Portworx Lighthouse",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Start Lighthouse",
+          "description": "Start the Lighthouse service. If this is disabled the influxdb service will also be disabled.",
+          "type": "boolean",
+          "default": false
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "CPU requirements",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "image": {
+          "title": "Lighthouse Image name",
+          "type": "string",
+          "default": "portworx/px-lighthouse:1.1.8"
+        },
+        "webui_port": {
+          "title": "WebUI Port",
+          "description": "",
+          "type": "integer",
+          "default": 8085
+        },
+        "company_name": {
+          "title": "Company Name",
+          "description": "Company Name to use for creating Lighthouse account",
+          "type": "string",
+          "default": "Portworx"
+        },
+        "admin_email": {
+          "title": "Administrator Email/Login",
+          "description": "Email to use for the Lighthouse account. Default password is admin and can be changed after first login. Used for resetting password and sending alerts.",
+          "type": "string",
+          "default": "portworx@yourcompany.com"
+        },
+        "admin_password": {
+          "title": "Administrator Password",
+          "description": "Password to use for the Lighthouse account.",
+          "type": "string",
+          "default": "admin"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "webui_port",
+        "company_name",
+        "admin_email",
+        "image"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx/4/marathon.json.mustache
+++ b/repo/packages/P/portworx/4/marathon.json.mustache
@@ -1,0 +1,122 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "user":"{{service.user}}",
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M\" &&  ./portworx-scheduler/bin/portworx ./portworx-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
+  "env": {
+    "SERVICE_NAME": "{{service.name}}",
+    "SERVICE_USER": "{{service.user}}",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+    "PORTWORX_CLUSTER_NAME": "{{node.portworx_cluster}}",
+    "PORTWORX_IMAGE_NAME": "{{{node.portworx_image}}}",
+    "PORTWORX_OPTIONS": "{{{node.portworx_options}}}",
+    {{#etcd.enabled}}
+    "ETCD_ENABLED": "{{etcd.enabled}}",
+    "PORTWORX_KVDB": "etcd://etcd-proxy-0-start.{{service.name}}.mesos:2379",
+    {{/etcd.enabled}}
+    {{^etcd.enabled}}
+    "PORTWORX_KVDB": "{{node.kvdb_servers}}",
+    {{/etcd.enabled}}
+    {{#node.container_parameters}}
+    "NODE_CONTAINER_PARAMETERS": "{{{node.container_parameters}}}",
+    {{/node.container_parameters}}
+
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    {{#service.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.secret_name}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+
+    "ETCD_PLACEMENT": "{{etcd.placement_constraint}}",
+    "ETCD_CPUS": "{{etcd.cpus}}",
+    "ETCD_MEM": "{{etcd.mem}}",
+    "ETCD_DISK_TYPE": "{{etcd.disk_type}}",
+    "ETCD_DISK_SIZE": "{{etcd.disk_size}}",
+    "ETCD_IMAGE": "{{etcd.image}}",
+    "ETCD_NODE_ADVERTISE_PORT": "{{etcd.node_advertise_port}}",
+    "ETCD_NODE_PEER_PORT": "{{etcd.node_peer_port}}",
+    "ETCD_PROXY_ADVERTISE_PORT": "{{etcd.proxy_advertise_port}}",
+
+    "INFLUXDB_PLACEMENT": "{{influxdb.placement_constraint}}",
+    "INFLUXDB_CPUS": "{{influxdb.cpus}}",
+    "INFLUXDB_MEM": "{{influxdb.mem}}",
+    "INFLUXDB_DISK_TYPE": "{{influxdb.disk_type}}",
+    "INFLUXDB_DISK_SIZE": "{{influxdb.disk_size}}",
+    "INFLUXDB_IMAGE": "{{influxdb.image}}",
+    "INFLUXDB_LISTEN_PORT": "{{influxdb.listen_port}}",
+
+    {{#lighthouse.enabled}}
+    "LIGHTHOUSE_ENABLED": "{{lighthouse.enabled}}",
+    {{/lighthouse.enabled}}
+    "LIGHTHOUSE_PLACEMENT": "{{lighthouse.placement_constraint}}",
+    "LIGHTHOUSE_CPUS": "{{lighthouse.cpus}}",
+    "LIGHTHOUSE_MEM": "{{lighthouse.mem}}",
+    "LIGHTHOUSE_IMAGE": "{{lighthouse.image}}",
+    "LIGHTHOUSE_WEBUI_PORT": "{{lighthouse.webui_port}}",
+    "LIGHTHOUSE_COMPANY_NAME": "{{lighthouse.company_name}}",
+    "LIGHTHOUSE_ADMIN_EMAIL": "{{lighthouse.admin_email}}",
+    "LIGHTHOUSE_ADMIN_PASSWORD": "{{lighthouse.admin_password}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 3
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx/4/package.json
+++ b/repo/packages/P/portworx/4/package.json
@@ -1,0 +1,31 @@
+{
+  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments. Portworx enables containerized applications to be persistent, portable and protected. For DCOS examples of Portworx, please see https://docs.portworx.com/scheduler/mesosphere-dcos/install.html",
+  "framework": true,
+  "licenses": [
+    {
+      "name": "Apache 2.0 License",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ],
+  "maintainer": "support@portworx.com",
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx",
+  "packagingVersion": "3.0",
+  "postInstallNotes": "To see how Portorx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures, please visit http://docs.portworx.com",
+  "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "preInstallNotes": "NOTE: Portworx requires a key-value database such as etcd for configuring storage. A highly availbale clustered etcd with persistent storage is preferred. You can start a 3-node etcd cluster using this framework, but for production it is recommended to operate an etcd cluster outside of your DC/OS environment. Instructions to set up etcd can be found here: https://docs.portworx.com/maintain/etcd.html \n\nLighthouse is a management and GUI service that allows you to manage your Portworx cluster. Lighthouse is disabled by default and can be enabled from the Lighthouse tab during install. Default username/password for Lighthouse is portworx@yourcompany.com/admin \n\nCertified packages are verified by Mesosphere for interoperability with DC/OS. Community packages are unverified and unreviewed content from the community. This is a community package. Be aware that this particular community package installs and operates as a system process in such a way that the detailed status of that process is not directly visible through DC/OS. Monitoring and managing the PX application should only be performed directly through the PX management utility and not through the DC/OS dashboard. Please visit https://docs.portworx.com/scheduler/mesosphere-dcos/install.html for detailed instructions.",
+  "scm": "https://github.com/portworx/px-dev",
+  "selected": false,
+  "tags": [
+    "portworx",
+    "storage",
+    "data",
+    "cloud",
+    "volume",
+    "encryption",
+    "s3",
+    "database"
+  ],
+  "version": "1.1-1.2.11.5-b02c112",
+  "website": "http://www.portworx.com/"
+}

--- a/repo/packages/P/portworx/4/resource.json
+++ b/repo/packages/P/portworx/4/resource.json
@@ -1,0 +1,64 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/portworx-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/bootstrap.zip"
+    },
+    "container": {
+      "docker": {
+        "portworx": "portworx/px-enterprise:1.2.11",
+        "lighthouse": "portworx/px-lighthouse:1.1.8",
+        "influxdb": "influxdb:latest",
+        "etcd": "mesosphere/etcd-mesos:latest"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-small.png",
+    "icon-medium": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-medium.png",
+    "icon-large": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "6349810a79917388bac9ef303e1ffbb0769462fc78720aa443daa2aed4219e3e"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/dcos-portworx-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "09260d6b54f0ce272c7431799d40ba0fec05ae93fadfd51105d3fea8f354a617"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/dcos-portworx-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "25c8fe82f78294e5164ed6fc1152ee1168fae899ca64c7f345818010684777ad"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/dcos-portworx.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx 1.1-1.2.11.5-b02c112 (automated commit)

Changes since revision 3:
0 files added: []
0 files removed: []
4 files changed:

```
--- 3/config.json
+++ 4/config.json
@@ -45,7 +45,7 @@
         "portworx_image": {
           "title": "Portworx Image name",
           "type": "string",
-          "default": "portworx/px-enterprise:1.2.10"
+          "default": "portworx/px-enterprise:1.2.11.5"
         },
         "portworx_options": {
           "title": "Portworx Options",
@@ -56,6 +56,12 @@
           "title": "KVDB servers",
           "description": "Comma seperated IP:PORT entries for the key value database (etcd or consul). If the etcd server is started using the pacakge this will be ignored",
           "type": "string",
+          "default": ""
+        },
+        "container_parameters": {
+          "title": "Container parameters",
+          "type": "string",
+          "description": "Any additional paramters to pass in to the Portworx container. For example environment variables can be passed in using \"-e\"",
           "default": ""
         },
         "count": {
@@ -79,14 +85,14 @@
       ]
     },
     "etcd": {
-      "description": "Start a 3 node etcd cluster. Required for Portworx if you don't have either etcd or consul already running",
+      "description": "Start a 3 node etcd cluster. Required for Portworx if you don't have either etcd or consul already running. For Production it is recommended to run an etcd cluster outside your DC/OS cluster.",
       "type": "object",
       "properties": {
         "enabled": {
           "title": "Start etcd",
           "description": "If disabled, please enter the external etcd server IP on the service tab.",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "placement_constraint": {
           "title": "Placement constraint",
@@ -213,7 +219,7 @@
           "title": "Start Lighthouse",
           "description": "Start the Lighthouse service. If this is disabled the influxdb service will also be disabled.",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "placement_constraint": {
           "title": "Placement constraint",
--- 3/marathon.json.mustache
+++ 4/marathon.json.mustache
@@ -38,6 +38,9 @@
     {{^etcd.enabled}}
     "PORTWORX_KVDB": "{{node.kvdb_servers}}",
     {{/etcd.enabled}}
+    {{#node.container_parameters}}
+    "NODE_CONTAINER_PARAMETERS": "{{{node.container_parameters}}}",
+    {{/node.container_parameters}}
 
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
--- 3/package.json
+++ 4/package.json
@@ -1,5 +1,5 @@
 {
-  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments.  Portworx enables containerized applications to be persistent, portable and protected.  For DCOS examples of Portworx, please see https://docs.portworx.com/scheduler/mesosphere-dcos/install.html",
+  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments. Portworx enables containerized applications to be persistent, portable and protected. For DCOS examples of Portworx, please see https://docs.portworx.com/scheduler/mesosphere-dcos/install.html",
   "framework": true,
   "licenses": [
     {
@@ -11,9 +11,9 @@
   "minDcosReleaseVersion": "1.9",
   "name": "portworx",
   "packagingVersion": "3.0",
-  "postInstallNotes": "To see how Portorx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures,  please visit http://docs.portworx.com",
+  "postInstallNotes": "To see how Portorx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures, please visit http://docs.portworx.com",
   "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
-  "preInstallNotes": "Certified packages are verified by Mesosphere for interoperability with DC/OS. Community packages are unverified and unreviewed content from the community. This is a community package. Be aware that this particular community package installs and operates as a system process in such a way that the detailed status of that process is not directly visible through DC/OS. Monitoring and managing the PX application should only be performed directly through the PX management utility and not through the DC/OS dashboard. Please visit https://docs.portworx.com/scheduler/mesosphere-dcos/install.html for detailed instructions. Default username/password for Lighthouse is portworx@yourcompany.com/admin",
+  "preInstallNotes": "NOTE: Portworx requires a key-value database such as etcd for configuring storage. A highly availbale clustered etcd with persistent storage is preferred. You can start a 3-node etcd cluster using this framework, but for production it is recommended to operate an etcd cluster outside of your DC/OS environment. Instructions to set up etcd can be found here: https://docs.portworx.com/maintain/etcd.html \n\nLighthouse is a management and GUI service that allows you to manage your Portworx cluster. Lighthouse is disabled by default and can be enabled from the Lighthouse tab during install. Default username/password for Lighthouse is portworx@yourcompany.com/admin \n\nCertified packages are verified by Mesosphere for interoperability with DC/OS. Community packages are unverified and unreviewed content from the community. This is a community package. Be aware that this particular community package installs and operates as a system process in such a way that the detailed status of that process is not directly visible through DC/OS. Monitoring and managing the PX application should only be performed directly through the PX management utility and not through the DC/OS dashboard. Please visit https://docs.portworx.com/scheduler/mesosphere-dcos/install.html for detailed instructions.",
   "scm": "https://github.com/portworx/px-dev",
   "selected": false,
   "tags": [
@@ -26,6 +26,6 @@
     "s3",
     "database"
   ],
-  "version": "1.0-1.2.10-8e408e5",
+  "version": "1.1-1.2.11.5-b02c112",
   "website": "http://www.portworx.com/"
 }
--- 3/resource.json
+++ 4/resource.json
@@ -3,13 +3,13 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.0-1.2.10-8e408e5/portworx-scheduler.zip",
-      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.0-1.2.10-8e408e5/executor.zip",
-      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.0-1.2.10-8e408e5/bootstrap.zip"
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/portworx-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/bootstrap.zip"
     },
     "container": {
       "docker": {
-        "portworx": "portworx/px-enterprise:1.2.10",
+        "portworx": "portworx/px-enterprise:1.2.11",
         "lighthouse": "portworx/px-lighthouse:1.1.8",
         "influxdb": "influxdb:latest",
         "etcd": "mesosphere/etcd-mesos:latest"
@@ -28,11 +28,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "26f74411ce010818f468bc69af68fad630dc3538d04ae9c6153c290ef6efc3d9"
+              "value": "6349810a79917388bac9ef303e1ffbb0769462fc78720aa443daa2aed4219e3e"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.0-1.2.10-8e408e5/dcos-portworx-darwin"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/dcos-portworx-darwin"
         }
       },
       "linux": {
@@ -40,11 +40,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "6c02f0478adbf9a917886fa11bb6fae582cbe6de2ed00bafcc05ee1b6869adcb"
+              "value": "09260d6b54f0ce272c7431799d40ba0fec05ae93fadfd51105d3fea8f354a617"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.0-1.2.10-8e408e5/dcos-portworx-linux"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/dcos-portworx-linux"
         }
       },
       "windows": {
@@ -52,11 +52,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "f81fbb01e480a23d78d3a683b089c7af68ff05a49b9c95e109f839b6e35c1df8"
+              "value": "25c8fe82f78294e5164ed6fc1152ee1168fae899ca64c7f345818010684777ad"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.0-1.2.10-8e408e5/dcos-portworx.exe"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.1-1.2.11.5-b02c112/dcos-portworx.exe"
         }
       }
     }
```
