### PR TITLE
Release portworx-couchdb 1.1-2.1.1-56b7afa (automated commit)



### DIFF
--- a/repo/packages/P/portworx-couchdb/0/config.json
+++ b/repo/packages/P/portworx-couchdb/0/config.json
@@ -1,0 +1,181 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS CouchDB service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the CouchDB service instance",
+          "type": "string",
+          "default": "portworx-couchdb"
+        },
+        "user": {
+          "title": "User",
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "node": {
+      "description": "DC/OS CouchDB node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of CouchDB nodes in the cluster",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Number of cpu shares allocated to the CouchDB process",
+          "type": "number",
+          "default": 0.5
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Amount of memory allocated to the CouchDB process (in MB)",
+          "type": "integer",
+          "default": 2048
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Amount of disk space allocated to CouchDB (in MB)",
+          "type": "integer",
+          "default": 10240
+        },
+        "portworx_volume_name": {
+          "title": "Portworx volume name",
+          "description": "Name of the volume used with Portworx driver",
+          "type": "string",
+          "default": "CouchDBVolume"
+        },
+        "portworx_volume_options": {
+          "title": "Portworx volume options",
+          "description": "Comma separated key=value pairs of options passed to Portworx driver",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "portworx_volume_name"
+      ]
+    },
+    "couchdb": {
+      "description": "CouchDB configuration properties",
+      "type": "object",
+      "properties": {
+        "couchdb_image": {
+          "title": "CouchDB image name",
+          "description": "CouchDB image to use for the cluster",
+          "type": "string",
+          "default": "couchdb:2.1.1"
+        },
+        "cluster_port": {
+          "title": "Cluster port",
+          "description": "Port used by clients to talk to CouchDB",
+          "type": "integer",
+          "default": 5984
+        },
+        "node_local_port": {
+          "title": "Node local port",
+          "description": "Port used only for maintenance and administrative tasks",
+          "type": "integer",
+          "default": 5986
+        },
+        "user": {
+          "title": "Admin user",
+          "description": "Admin user to configure CouchDB",
+          "type": "string",
+          "default": "admin"
+        },
+        "password": {
+          "title": "Admin password",
+          "description": "Password of the CouchDB admin user",
+          "type": "string",
+          "default": "password"
+        },
+        "cookie": {
+          "title": "Cookie",
+          "description": "Cookie used to form the Erlang cluster",
+          "type": "string",
+          "default": "couchdbcookie"
+        },
+        "secret": {
+          "title": "Secret",
+          "description": "Secret token used for proxy and cookie authentication",
+          "type": "string",
+          "default": "couchdbsecret"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "cluster_port",
+        "node_local_port",
+        "user",
+        "password",
+        "cookie"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx-couchdb/0/marathon.json.mustache
+++ b/repo/packages/P/portworx-couchdb/0/marathon.json.mustache
@@ -1,0 +1,100 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 0.5,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./couchdb-scheduler/bin/couchdb ./couchdb-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    "COUCHDB_CPUS": "{{node.cpus}}",
+    "COUCHDB_MEM_MB": "{{node.mem}}",
+    "COUCHDB_DISK_MB": "{{node.disk}}",
+    "COUCHDB_DOCKER_VOLUME_NAME": "{{{node.portworx_volume_name}}}",
+    "COUCHDB_DOCKER_DRIVER_OPTIONS": "{{{node.portworx_volume_options}}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service_account_secret}}
+
+    "COUCHDB_PORT": "{{couchdb.cluster_port}}",
+    "COUCHDB_NODE_PORT": "{{couchdb.node_local_port}}",
+    "COUCHDB_USER": "{{couchdb.user}}",
+    "COUCHDB_PASSWORD": "{{couchdb.password}}",
+    "COUCHDB_COOKIE": "{{couchdb.cookie}}",
+    "COUCHDB_SECRET": "{{couchdb.secret}}",
+
+    "COUCHDB_DOCKER_IMAGE": "{{couchdb.couchdb_image}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "SCHEDULER_URI": "{{resource.assets.uris.scheduler-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-couchdb/0/package.json
+++ b/repo/packages/P/portworx-couchdb/0/package.json
@@ -1,0 +1,17 @@
+{
+  "description": "Apache CouchDB backed by Portworx volumes",
+  "framework": true,
+  "maintainer": "support@portworx.com",
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx-couchdb",
+  "packagingVersion": "4.0",
+  "postInstallNotes": "DC/OS portworx-couchdb is being installed!\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/frameworks.html",
+  "postUninstallNotes": "DC/OS portworx-couchdb has been uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.5 CPU | 2048 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
+  "selected": false,
+  "tags": [
+    "couchdb",
+    "portworx"
+  ],
+  "version": "1.1-2.1.1-56b7afa"
+}

--- a/repo/packages/P/portworx-couchdb/0/resource.json
+++ b/repo/packages/P/portworx-couchdb/0/resource.json
@@ -1,0 +1,60 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/couchdb-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/executor.zip"
+    },
+    "container": {
+      "docker": {
+        "couchdb": "couchdb:2.1.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-couchdb/img/couchdb-small.png",
+    "icon-medium": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-couchdb/img/couchdb-medium.png",
+    "icon-large": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-couchdb/img/couchdb-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "c7191c0f913533ff3d978d7db2e82f35bb1e52e87f7f2f48f6f4eec93cc8f2ef"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/dcos-portworx-couchdb-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "ade0c8aeabc998fcda49b73b102a3c784840669c022d3e974705ec284467b590"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/dcos-portworx-couchdb-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "43ae4087bf5735a77ff9d2e7e2af1b2a46cfc730af6382df6c24bf37963db8b7"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/dcos-portworx-couchdb.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx-couchdb 1.1-2.1.1-56b7afa (automated commit)

Changes since revision -1:
4 files added: [package.json, resource.json, marathon.json.mustache, config.json]
0 files removed: []
0 files changed:

```
```
