### PR TITLE
Release portworx-kafka 1.2-1.0.0-2b3d93b (automated commit)



### DIFF
--- a/repo/packages/P/portworx-kafka/100/config.json
+++ b/repo/packages/P/portworx-kafka/100/config.json
@@ -1,0 +1,1006 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "Apache Kafka",
+          "type": "string",
+          "default": "portworx-kafka"
+        },
+        "user": {
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        },
+        "placement_constraint": {
+          "description": "Placement constraints for broker nodes. Example: [[\"rack_id\", \"LIKE\", \"rack-foo-.*\"], [\"rack_id\", \"MAX_PER\", \"2\"]]",
+          "type": "string",
+          "default": "[[\"hostname\", \"MAX_PER\", \"1\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "deploy_strategy": {
+          "description": "Deployment phase strategy. See documentation. [serial, serial-canary, parallel-canary, parallel]",
+          "type": "string",
+          "enum": [
+            "serial",
+            "serial-canary",
+            "parallel-canary",
+            "parallel"
+          ],
+          "default": "serial"
+        },
+        "security": {
+          "description": "Kafka security settings",
+          "type": "object",
+          "allOf": [
+            {
+              "not": {
+                "properties": {
+                  "transport_encryption": {
+                    "properties": {
+                      "enabled": {
+                        "enum": [
+                          false
+                        ]
+                      }
+                    }
+                  },
+                  "ssl_authentication": {
+                    "properties": {
+                      "enabled": {
+                        "enum": [
+                          true
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": {
+            "ssl_authentication": {
+              "type": "object",
+              "description": "SSL Authn/z configuration properties.",
+              "properties": {
+                "enabled": {
+                  "description": "Enable SSL authentication.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "kerberos": {
+              "type": "object",
+              "description": "Kerberos configuration properties.",
+              "properties": {
+                "enabled": {
+                  "description": "Enable kerberos authentication.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "enabled_for_zookeeper": {
+                  "description": "Enabled Kerberos authentication for communication with Apache Zookeeper",
+                  "type": "boolean",
+                  "default": false
+                },
+                "kdc": {
+                  "description": "KDC settings for Kerberos",
+                  "type": "object",
+                  "properties": {
+                    "hostname": {
+                      "type": "string",
+                      "description": "The name or address of a host running a KDC for the realm."
+                    },
+                    "port": {
+                      "type": "integer",
+                      "description": "The port of the host running a KDC for that realm."
+                    }
+                  }
+                },
+                "primary": {
+                  "type": "string",
+                  "description": "The Kerberos primary used by Kafka tasks.  The full principal will be <service.kerberos.primary>/<mesos_dns_address>@<service.kerberos.realm>",
+                  "default": "kafka"
+                },
+                "realm": {
+                  "type": "string",
+                  "description": "The Kerberos realm used to render the principal of Kafka tasks."
+                },
+                "keytab_secret": {
+                  "type": "string",
+                  "description": "The name of the DC/OS secret storing the keytab"
+                },
+                "debug": {
+                  "type": "boolean",
+                  "description": "Turn debug Kerberos logging on or off to assist in diagnosing issues with Kerberos authentication.",
+                  "default": false
+                }
+              }
+            },
+            "transport_encryption": {
+              "type": "object",
+              "description": "Transport encryption settings",
+              "properties": {
+                "enabled": {
+                  "description": "Enable transport encryption (TLS)",
+                  "type": "boolean",
+                  "default": false
+                },
+                "allow_plaintext": {
+                  "description": "Allow plaintext alongside encrypted traffic",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "authorization": {
+              "type": "object",
+              "description": "Authorization configuration properties",
+              "properties": {
+                "enabled": {
+                  "description": "Enable authorization.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "super_users": {
+                  "description": "Semi-colon delimited list of principals. For Kerberos principals, these will be of the form User:<Kerberos-Primary>. For TLS, they will be of the form User:<CN of TLS cert> (for the TLS cert CN=test-user,OU=,O=Confluent,L=London,ST=London,C=GB, the user would be test-user)",
+                  "type": "string",
+                  "default": ""
+                },
+                "allow_everyone_if_no_acl_found": {
+                  "description": "Allow any user to perform an action if no ACL is found for the resource.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "deploy_strategy"
+      ]
+    },
+    "brokers": {
+      "description": "Kafka broker configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Broker cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Broker mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Kafka process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Kafka broker process.",
+              "default": 512
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Broker disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 5000
+        },
+        "disk_path": {
+          "type": "string",
+          "description": "Relative path of consistent disk",
+          "default": "kafka-broker-data"
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "KafkaVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "count": {
+          "description": "Number of brokers to run",
+          "type": "number",
+          "default": 3
+        },
+        "port": {
+          "description": "Port for broker to listen on",
+          "type": "integer",
+          "default": 0
+        },
+        "port_tls": {
+          "description": "Port for broker to listen on for TLS connections, if the TLS is enabled",
+          "type": "integer",
+          "default": 0
+        },
+        "kill_grace_period": {
+          "description": "The number of seconds of grace to await a clean shutdown following SIGTERM before sending SIGKILL, default: `30`",
+          "type": "integer",
+          "default": 30
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count",
+        "portworx_volume_name"
+      ]
+    },
+    "kafka": {
+      "description": "Kafka service configuration properties",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kafka_zookeeper_uri": {
+          "title": "Custom Zookeeper path",
+          "description": "The address of the cluster to be used by Kafka, or empty to use DC/OS' instance. Example: myhost:2181/mynode",
+          "type": "string",
+          "default": ""
+        },
+        "auto_create_topics_enable": {
+          "title": "auto.create.topics.enable",
+          "description": "Enable auto creation of topic on the server",
+          "type": "boolean",
+          "default": true
+        },
+        "kafka_advertise_host_ip": {
+          "description": "[DEPRECATED] This configuration parameter has been deprecated and will be removed in a future release. When set to true, and no security settings are enabled, kafka's advertised.listeners property is set to PLAINTEXT://<broker-ip>:<broker-port>. When the setting is false and no security is enabled, then advertised.listeners is NOT set. When security is enabled, the advertised.listeners property will be set to broker hostnames.",
+          "type": "boolean",
+          "default": true
+        },
+        "auto_leader_rebalance_enable": {
+          "title": "auto.leader.rebalance.enable",
+          "description": "Enables auto leader balancing. A background thread checks and triggers leader balance if required at regular intervals",
+          "type": "boolean",
+          "default": true
+        },
+        "background_threads": {
+          "title": "background.threads",
+          "description": "The number of threads to use for various background processing tasks",
+          "type": "integer",
+          "default": 10,
+          "minimum": 1
+        },
+        "compression_type": {
+          "title": "compression.type",
+          "description": "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.",
+          "type": "string",
+          "default": "producer"
+        },
+        "delete_topic_enable": {
+          "title": "delete.topic.enable",
+          "description": "Enables delete topic. Delete topic through the admin tool will have no effect if this config is turned off",
+          "type": "boolean",
+          "default": false
+        },
+        "delete_records_purgatory_purge_interval_requests": {
+          "title": "delete.records.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the delete records request purgatory",
+          "type": "integer",
+          "default": 1
+        },
+        "leader_imbalance_check_interval_seconds": {
+          "title": "leader.imbalance.check.interval.seconds",
+          "description": "The frequency with which the partition rebalance check is triggered by the controller",
+          "type": "integer",
+          "default": 300
+        },
+        "leader_imbalance_per_broker_percentage": {
+          "title": "leader.imbalance.per.broker.percentage",
+          "description": "The ratio of leader imbalance allowed per broker. The controller would trigger a leader balance if it goes above this value per broker. The value is specified in percentage.",
+          "type": "integer",
+          "default": 10
+        },
+        "log_flush_interval_messages": {
+          "title": "log.flush.interval.messages",
+          "description": "The number of messages accumulated on a log partition before messages are flushed to disk",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "log_flush_interval_ms": {
+          "title": "log.flush.interval.ms",
+          "description": "The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used",
+          "type": "integer"
+        },
+        "log_flush_offset_checkpoint_interval_ms": {
+          "title": "log.flush.offset.checkpoint.interval.ms",
+          "description": "The frequency with which we update the persistent record of the last flush which acts as the log recovery point",
+          "type": "integer",
+          "default": 60000,
+          "minimum": 0
+        },
+        "log_flush_scheduler_interval_ms": {
+          "title": "log.flush.scheduler.interval.ms",
+          "description": "The frequency in ms that the log flusher checks whether any log needs to be flushed to disk",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "log_flush_start_offset_checkpoint_interval_ms": {
+          "title": "log.flush.start.offset.checkpoint.interval.ms",
+          "description": "The frequency with which we update the persistent record of log start offset",
+          "type": "integer",
+          "default": 60000,
+          "minimum": 0
+        },
+        "log_retention_bytes": {
+          "title": "log.retention.bytes",
+          "description": "The maximum size of the log before deleting it",
+          "type": "string",
+          "default": "-1"
+        },
+        "log_retention_ms": {
+          "title": "log.retention.ms",
+          "description": "The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used",
+          "type": "integer"
+        },
+        "log_retention_minutes": {
+          "title": "log.retention.minutes",
+          "description": "The number of minutes to keep a log file before deleting it (in minutes), secondary to log.retention.ms property. If not set, the value in log.retention.hours is used",
+          "type": "integer"
+        },
+        "log_retention_hours": {
+          "title": "log.retention.hours",
+          "description": "The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property",
+          "type": "integer",
+          "default": 168
+        },
+        "log_roll_ms": {
+          "title": "log.roll.ms",
+          "description": "The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in log.roll.hours is used",
+          "type": "integer"
+        },
+        "log_roll_jitter_ms": {
+          "title": "log.roll.jitter.ms",
+          "description": "The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used",
+          "type": "integer"
+        },
+        "log_roll_hours": {
+          "title": "log.roll.hours",
+          "description": "The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property",
+          "type": "integer",
+          "default": 168,
+          "minimum": 1
+        },
+        "log_roll_jitter_hours": {
+          "title": "log.roll.jitter.hours",
+          "description": "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0
+        },
+        "log_segment_bytes": {
+          "title": "log.segment.bytes",
+          "description": "The maximum size of a single log file",
+          "type": "integer",
+          "default": 1073741824,
+          "minimum": 14
+        },
+        "log_segment_delete_delay_ms": {
+          "title": "log.segment.delete.delay.ms",
+          "description": "The amount of time to wait before deleting a file from the filesystem",
+          "type": "integer",
+          "default": 60000,
+          "minimum": 0
+        },
+        "message_max_bytes": {
+          "title": "message.max.bytes",
+          "description": "The largest record batch size allowed by Kafka. If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that the they can fetch record batches this large.\nIn the latest message format version, records are always grouped into batches for efficiency. In previous message format versions, uncompressed records are not grouped into batches and this limit only applies to a single record in that case.\nThis can be set per topic with the topic level max.message.bytes config.",
+          "type": "integer",
+          "default": 1000012,
+          "minimum": 0
+        },
+        "min_insync_replicas": {
+          "title": "min.insync.replicas",
+          "description": "When a producer sets acks to \"all\" (or \"-1\"), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the producer will raise an exception (either NotEnoughReplicas or NotEnoughReplicasAfterAppend).\nWhen used together, min.insync.replicas and acks allow you to enforce greater durability guarantees. A typical scenario would be to create a topic with a replication factor of 3, set min.insync.replicas to 2, and produce with acks of \"all\". This will ensure that the producer raises an exception if a majority of replicas do not receive a write.",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
+        "num_io_threads": {
+          "title": "num.io.threads",
+          "description": "The number of threads that the server uses for processing requests, which may include disk I/O",
+          "type": "integer",
+          "default": 8,
+          "minimum": 1
+        },
+        "num_network_threads": {
+          "title": "num.network.threads",
+          "description": "The number of threads that the server uses for receiving requests from the network and sending responses to the network",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
+        },
+        "num_recovery_threads_per_data_dir": {
+          "title": "num.recovery.threads.per.data.dir",
+          "description": "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
+        "num_replica_fetchers": {
+          "title": "num.replica.fetchers",
+          "description": "Number of fetcher threads used to replicate messages from a source broker. Increasing this value can increase the degree of I/O parallelism in the follower broker.",
+          "type": "integer",
+          "default": 1
+        },
+        "offset_metadata_max_bytes": {
+          "title": "offset.metadata.max.bytes",
+          "description": "The maximum size for a metadata entry associated with an offset commit",
+          "type": "integer",
+          "default": 4096
+        },
+        "offsets_commit_required_acks": {
+          "title": "offsets.commit.required.acks",
+          "description": "The required acks before the commit can be accepted. In general, the default (-1) should not be overridden",
+          "type": "integer",
+          "default": -1
+        },
+        "offsets_commit_timeout_ms": {
+          "title": "offsets.commit.timeout.ms",
+          "description": "Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout.",
+          "type": "integer",
+          "default": 5000,
+          "minimum": 1
+        },
+        "offsets_load_buffer_size": {
+          "title": "offsets.load.buffer.size",
+          "description": "Batch size for reading from the offsets segments when loading offsets into the cache.",
+          "type": "integer",
+          "default": 5242880,
+          "minimum": 1
+        },
+        "offsets_retention_check_interval_ms": {
+          "title": "offsets.retention.check.interval.ms",
+          "description": "Frequency at which to check for stale offsets",
+          "type": "integer",
+          "default": 600000,
+          "minimum": 1
+        },
+        "offsets_retention_minutes": {
+          "title": "offsets.retention.minutes",
+          "description": "Offsets older than this retention period will be discarded",
+          "type": "integer",
+          "default": 1440,
+          "minimum": 1
+        },
+        "offsets_topic_compression_codec": {
+          "title": "offsets.topic.compression.codec",
+          "description": "Compression codec for the offsets topic - compression may be used to achieve \"atomic\" commits",
+          "type": "integer",
+          "default": 0
+        },
+        "offsets_topic_num_partitions": {
+          "title": "offsets.topic.num.partitions",
+          "description": "The number of partitions for the offset commit topic (should not change after deployment)",
+          "type": "integer",
+          "default": 50,
+          "minimum": 1
+        },
+        "offsets_topic_replication_factor": {
+          "title": "offsets.topic.replication.factor",
+          "description": "The replication factor for the offsets topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
+        },
+        "offsets_topic_segment_bytes": {
+          "title": "offsets.topic.segment.bytes",
+          "description": "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
+          "type": "integer",
+          "default": 104857600,
+          "minimum": 1
+        },
+        "queued_max_requests": {
+          "title": "queued.max.requests",
+          "description": "The number of queued requests allowed before blocking the network threads",
+          "type": "integer",
+          "default": 500,
+          "minimum": 1
+        },
+        "queued_max_request_bytes": {
+          "title": "queued.max.request.bytes",
+          "description": "The number of queued bytes allowed before no more requests are read",
+          "type": "integer",
+          "default": -1
+        },
+        "quota_consumer_default": {
+          "title": "quota.consumer.default",
+          "description": "Used only when dynamic default quotas are not configured for or in Zookeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "quota_producer_default": {
+          "title": "quota.producer.default",
+          "description": "Used only when dynamic default quotas are not configured for , or in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second",
+          "type": "string",
+          "default": "9223372036854775807"
+        },
+        "replica_fetch_max_bytes": {
+          "title": "replica.fetch.max.bytes",
+          "description": "The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config).",
+          "type": "integer",
+          "default": 1048576
+        },
+        "replica_fetch_min_bytes": {
+          "title": "replica.fetch.min.bytes",
+          "description": "Minimum bytes expected for each fetch response. If not enough bytes, wait up to replicaMaxWaitTimeMs",
+          "type": "integer",
+          "default": 1
+        },
+        "replica_fetch_wait_max_ms": {
+          "title": "replica.fetch.wait.max.ms",
+          "description": "Max wait time for each fetcher request issued by follower replicas. This value should always be less than the replica.lag.time.max.ms at all times to prevent frequent shrinking of ISR for low throughput topics",
+          "type": "integer",
+          "default": 500
+        },
+        "replica_fetch_response_max_bytes": {
+          "title": "replica.fetch.response.max.bytes",
+          "description": "Maximum bytes expected for the entire fetch response. Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config).",
+          "type": "integer",
+          "default": 10485760,
+          "minimum": 0
+        },
+        "replica_high_watermark_checkpoint_interval_ms": {
+          "title": "replica.high.watermark.checkpoint.interval.ms",
+          "description": "The frequency with which the high watermark is saved out to disk",
+          "type": "integer",
+          "default": 5000
+        },
+        "replica_lag_time_max_ms": {
+          "title": "replica.lag.time.max.ms",
+          "description": "If a follower hasn't sent any fetch requests or hasn't consumed up to the leaders log end offset for at least this time, the leader will remove the follower from isr",
+          "type": "integer",
+          "default": 10000
+        },
+        "replica_socket_receive_buffer_bytes": {
+          "title": "replica.socket.receive.buffer.bytes",
+          "description": "The socket receive buffer for network requests",
+          "type": "integer",
+          "default": 65536
+        },
+        "replica_socket_timeout_ms": {
+          "title": "replica.socket.timeout.ms",
+          "description": "The socket timeout for network requests. Its value should be at least replica.fetch.wait.max.ms",
+          "type": "integer",
+          "default": 30000
+        },
+        "replication_quota_window_num": {
+          "title": "replication.quota.window.num",
+          "description": "The number of samples to retain in memory for replication quotas",
+          "type": "integer",
+          "default": 11,
+          "minimum": 1
+        },
+        "replication_quota_window_size_seconds": {
+          "title": "replication.quota.window.size.seconds",
+          "description": "The time span of each sample for replication quotas",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
+        "request_timeout_ms": {
+          "title": "request.timeout.ms",
+          "description": "The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.",
+          "type": "integer",
+          "default": 30000
+        },
+        "socket_receive_buffer_bytes": {
+          "title": "socket.receive.buffer.bytes",
+          "description": "The SO_RCVBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.",
+          "type": "integer",
+          "default": 102400
+        },
+        "socket_request_max_bytes": {
+          "title": "socket.request.max.bytes",
+          "description": "The maximum number of bytes in a socket request",
+          "type": "integer",
+          "default": 104857600,
+          "minimum": 1
+        },
+        "socket_send_buffer_bytes": {
+          "title": "socket.send.buffer.bytes",
+          "description": "The SO_SNDBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.",
+          "type": "integer",
+          "default": 102400
+        },
+        "unclean_leader_election_enable": {
+          "title": "unclean.leader.election.enable",
+          "description": "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss",
+          "type": "boolean",
+          "default": false
+        },
+        "zookeeper_session_timeout_ms": {
+          "title": "zookeeper.session.timeout.ms",
+          "description": "Zookeeper session timeout",
+          "type": "integer",
+          "default": 6000
+        },
+        "connections_max_idle_ms": {
+          "title": "connections.max.idle.ms",
+          "description": "Idle connections timeout: the server socket processor threads close the connections that idle more than this",
+          "type": "integer",
+          "default": 600000
+        },
+        "controlled_shutdown_enable": {
+          "title": "controlled.shutdown.enable",
+          "description": "Enable controlled shutdown of the server",
+          "type": "boolean",
+          "default": true
+        },
+        "controlled_shutdown_max_retries": {
+          "title": "controlled.shutdown.max.retries",
+          "description": "Controlled shutdown can fail for multiple reasons. This determines the number of retries when such failure happens",
+          "type": "integer",
+          "default": 3
+        },
+        "controlled_shutdown_retry_backoff_ms": {
+          "title": "controlled.shutdown.retry.backoff.ms",
+          "description": "Before each retry, the system needs time to recover from the state that caused the previous failure (Controller fail over, replica lag etc). This config determines the amount of time to wait before retrying.",
+          "type": "integer",
+          "default": 5000
+        },
+        "controller_socket_timeout_ms": {
+          "title": "controller.socket.timeout.ms",
+          "description": "The socket timeout for controller-to-broker channels",
+          "type": "integer",
+          "default": 30000
+        },
+        "default_replication_factor": {
+          "title": "default.replication.factor",
+          "description": "Default replication factors for automatically created topics",
+          "type": "integer",
+          "default": 1
+        },
+        "fetch_purgatory_purge_interval_requests": {
+          "title": "fetch.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the fetch request purgatory",
+          "type": "integer",
+          "default": 1000
+        },
+        "group_max_session_timeout_ms": {
+          "title": "group.max.session.timeout.ms",
+          "description": "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.",
+          "type": "integer",
+          "default": 300000
+        },
+        "group_min_session_timeout_ms": {
+          "title": "group.min.session.timeout.ms",
+          "description": "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources.",
+          "type": "integer",
+          "default": 6000
+        },
+        "group_initial_rebalance_delay_ms": {
+          "title": "group.initial.rebalance.delay.ms",
+          "description": "The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins.",
+          "type": "integer",
+          "default": 3000
+        },
+        "inter_broker_protocol_version": {
+          "type": "string",
+          "title": "inter.broker.protocol.version",
+          "description": "Specify which version of the inter-broker protocol will be used, which must align with log.message.format.version. This is typically bumped *serially* one broker at a time, *after* all brokers were upgraded to a new version. Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1, 0.10.0.0, 0.10.1.x, 0.10.2.x, 0.11.0.0. Check ApiVersion for the full list.",
+          "default": "1.0"
+        },
+        "log_message_format_version": {
+          "type": "string",
+          "title": "log.message.format.version",
+          "description": "Specify which version of the log message format will be used, which must align with inter.broker.protocol.version. This is a new setting as of 0.10.0.0, and should be left at 0.9.0 until clients are updated to 0.10.0.x. Similarly it should be left at 0.10.0 until all clients are updated to 0.11.0. This is typically bumped *serially* one broker at a time, *after* all inter-protocol versions are updated. Clients on earlier versions may see a performance penalty if this is increased before they've upgraded. See the latest Kafka documentation for details.",
+          "default": "1.0"
+        },
+        "log_cleaner_backoff_ms": {
+          "title": "log.cleaner.backoff.ms",
+          "description": "The amount of time to sleep when there are no logs to clean",
+          "type": "integer",
+          "default": 15000,
+          "minimum": 0
+        },
+        "log_cleaner_dedupe_buffer_size": {
+          "title": "log.cleaner.dedupe.buffer.size",
+          "description": "The total memory used for log deduplication across all cleaner threads",
+          "type": "integer",
+          "default": 134217728
+        },
+        "log_cleaner_delete_retention_ms": {
+          "title": "log.cleaner.delete.retention.ms",
+          "description": "How long are delete records retained?",
+          "type": "integer",
+          "default": 86400000
+        },
+        "log_cleaner_enable": {
+          "title": "log.cleaner.enable",
+          "description": "Enable the log cleaner process to run on the server. Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.",
+          "type": "boolean",
+          "default": true
+        },
+        "log_cleaner_io_buffer_load_factor": {
+          "title": "log.cleaner.io.buffer.load.factor",
+          "description": "Log cleaner dedupe buffer load factor. The percentage full the dedupe buffer can become. A higher value will allow more log to be cleaned at once but will lead to more hash collisions",
+          "type": "number",
+          "default": 0.9
+        },
+        "log_cleaner_io_buffer_size": {
+          "title": "log.cleaner.io.buffer.size",
+          "description": "The total memory used for log cleaner I/O buffers across all cleaner threads",
+          "type": "integer",
+          "default": 524288,
+          "minimum": 0
+        },
+        "log_cleaner_io_max_bytes_per_second": {
+          "title": "log.cleaner.io.max.bytes.per.second",
+          "description": "The log cleaner will be throttled so that the sum of its read and write i/o will be less than this value on average",
+          "type": "number",
+          "default": 1.7976931348623157e+308
+        },
+        "log_cleaner_min_cleanable_ratio": {
+          "title": "log.cleaner.min.cleanable.ratio",
+          "description": "The minimum ratio of dirty log to total log for a log to eligible for cleaning",
+          "type": "number",
+          "default": 0.5
+        },
+        "log_cleaner_min_compaction_lag_ms": {
+          "title": "log.cleaner.min.compaction.lag.ms",
+          "description": "The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.",
+          "type": "integer",
+          "default": 0
+        },
+        "log_cleaner_threads": {
+          "title": "log.cleaner.threads",
+          "description": "The number of background threads to use for log cleaning",
+          "type": "integer",
+          "default": 1,
+          "minimum": 0
+        },
+        "log_cleanup_policy": {
+          "type": "string",
+          "title": "log.cleanup.policy",
+          "description": "The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: \"delete\" and \"compact\"",
+          "default": "delete"
+        },
+        "log_index_interval_bytes": {
+          "title": "log.index.interval.bytes",
+          "description": "The interval with which we add an entry to the offset index",
+          "type": "integer",
+          "default": 4096,
+          "minimum": 0
+        },
+        "log_index_size_max_bytes": {
+          "title": "log.index.size.max.bytes",
+          "description": "The maximum size in bytes of the offset index",
+          "type": "integer",
+          "default": 10485760,
+          "minimum": 4
+        },
+        "log_preallocate": {
+          "title": "log.preallocate",
+          "description": "Should pre allocate file when create new segment? If you are using Kafka on Windows, you probably need to set it to true.",
+          "type": "boolean",
+          "default": false
+        },
+        "log_retention_check_interval_ms": {
+          "title": "log.retention.check.interval.ms",
+          "description": "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion",
+          "type": "integer",
+          "default": 300000,
+          "minimum": 1
+        },
+        "max_connections_per_ip": {
+          "title": "max.connections.per.ip",
+          "description": "The maximum number of connections we allow from each ip address",
+          "type": "integer",
+          "default": 2147483647,
+          "minimum": 1
+        },
+        "max_connections_per_ip_overrides": {
+          "type": "string",
+          "title": "max.connections.per.ip.overrides",
+          "description": "Per-ip or hostname overrides to the default maximum number of connections",
+          "default": ""
+        },
+        "num_partitions": {
+          "title": "num.partitions",
+          "description": "The default number of log partitions per topic",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
+        "producer_purgatory_purge_interval_requests": {
+          "title": "producer.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the producer request purgatory",
+          "type": "integer",
+          "default": 1000
+        },
+        "replica_fetch_backoff_ms": {
+          "title": "replica.fetch.backoff.ms",
+          "description": "The amount of time to sleep when fetch partition error occurs.",
+          "type": "integer",
+          "default": 1000,
+          "minimum": 0
+        },
+        "reserved_broker_max_id": {
+          "title": "reserved.broker.max.id",
+          "description": "Max number that can be used for a broker.id",
+          "type": "integer",
+          "default": 1000,
+          "minimum": 0
+        },
+        "kafka_metrics_reporters": {
+          "title": "kafka.metric.reporters",
+          "description": "Old style metrics reporter",
+          "type": "string",
+          "default": "com.airbnb.kafka.kafka08.StatsdMetricsReporter"
+        },
+        "metric_reporters": {
+          "title": "metric.reporters",
+          "description": "Java class to collect/report broker metrics",
+          "type": "string",
+          "default": "com.airbnb.kafka.kafka09.StatsdMetricsReporter"
+        },
+        "metrics_num_samples": {
+          "title": "metrics.num.samples",
+          "description": "The number of samples maintained to compute metrics.",
+          "type": "integer",
+          "default": 2,
+          "minimum": 1
+        },
+        "metrics_sample_window_ms": {
+          "title": "metrics.sample.window.ms",
+          "description": "The window of time a metrics sample is computed over.",
+          "type": "integer",
+          "default": 30000,
+          "minimum": 1
+        },
+        "quota_window_num": {
+          "title": "quota.window.num",
+          "description": "The number of samples to retain in memory for client quotas",
+          "type": "integer",
+          "default": 11,
+          "minimum": 1
+        },
+        "quota_window_size_seconds": {
+          "title": "quota.window.size.seconds",
+          "description": "The time span of each sample for client quotas",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
+        "transaction_state_log_segment_bytes": {
+          "title": "transaction.state.log.segment.bytes",
+          "description": "The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
+          "type": "integer",
+          "default": 104857600,
+          "minimum": 1
+        },
+        "transaction_remove_expired_transaction_cleanup_interval_ms": {
+          "title": "transaction.remove.expired.transaction.cleanup.interval.ms",
+          "description": "The interval at which to remove transactions that have expired due to transactional.id.expiration.ms passing",
+          "type": "integer",
+          "default": 3600000,
+          "minimum": 1
+        },
+        "transaction_max_timeout_ms": {
+          "title": "transaction.max.timeout.ms",
+          "description": "The maximum allowed timeout for transactions. If a client\u2019s requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.",
+          "type": "integer",
+          "default": 900000,
+          "minimum": 1
+        },
+        "transaction_state_log_num_partitions": {
+          "title": "transaction.state.log.num.partitions",
+          "description": "The number of partitions for the transaction topic (should not change after deployment).",
+          "type": "integer",
+          "default": 50,
+          "minimum": 1
+        },
+        "transaction_abort_timed_out_transaction_cleanup_interval_ms": {
+          "title": "transaction.abort.timed.out.transaction.cleanup.interval.ms",
+          "description": "The interval at which to rollback transactions that have timed out",
+          "type": "integer",
+          "default": 60000,
+          "minimum": 1
+        },
+        "transaction_state_log_load_buffer_size": {
+          "title": "transaction.state.log.load.buffer.size",
+          "description": "Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache.",
+          "type": "integer",
+          "default": 5242880,
+          "minimum": 1
+        },
+        "transaction_state_log_replication_factor": {
+          "title": "transaction.state.log.replication.factor",
+          "description": "The replication factor for the transaction topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
+        },
+        "transaction_state_log_min_isr": {
+          "title": "transaction.state.log.min.isr",
+          "description": "Overridden min.insync.replicas config for the transaction topic.",
+          "type": "integer",
+          "default": 2,
+          "minimum": 1
+        },
+        "transactional_id_expiration_ms": {
+          "title": "transactional.id.expiration.ms",
+          "description": "The maximum amount of time in ms that the transaction coordinator will wait before proactively expire a producer's transactional id without receiving any transaction status updates from it.",
+          "type": "integer",
+          "default": 604800000,
+          "minimum": 1
+        },
+        "zookeeper_sync_time_ms": {
+          "title": "zookeeper.sync.time.ms",
+          "description": "How far a ZK follower can be behind a ZK leader",
+          "type": "integer",
+          "default": 2000
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/P/portworx-kafka/100/marathon.json.mustache
+++ b/repo/packages/P/portworx-kafka/100/marathon.json.mustache
@@ -1,0 +1,272 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./kafka-scheduler/bin/kafka ./kafka-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "PACKAGE_NAME": "portworx-kafka",
+    "PACKAGE_VERSION": "1.2-1.0.0-2b3d93b",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1526700944908",
+    "PACKAGE_BUILD_TIME_STR": "Sat May 19 2018 03:35:44 +0000",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "BROKER_KILL_GRACE_PERIOD": "{{brokers.kill_grace_period}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "KAFKA_URI": "{{resource.assets.uris.kafka-tgz}}",
+    "KAFKA_JAVA_URI": "{{resource.assets.uris.kafka-jre-tar-gz}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "KAFKA_STATSD_URI": "{{resource.assets.uris.kafka-statsd-jar}}",
+    "CLIENT_STATSD_URI": "{{resource.assets.uris.statsd-client-jar}}",
+    "SETUP_HELPER_URI": "{{resource.assets.uris.setup-helper-zip}}",
+    "ZOOKEEPER_CLIENT_URI": "{{resource.assets.uris.zookeeper-client-jar}}",
+    "CUSTOM_KAFKA_PRINCIPAL_URI": "{{resource.assets.uris.custom-kafka-principal-jar}}",
+    "KAFKA_VERSION": "2.11-1.0.0",
+
+    "PLACEMENT_CONSTRAINTS": "{{{service.placement_constraint}}}",
+    "DEPLOY_STRATEGY":"{{service.deploy_strategy}}",
+    "BROKER_COUNT": "{{brokers.count}}",
+    {{^service.security.kerberos.enabled}}
+    {{#service.security.transport_encryption.enabled}}
+    {{#service.security.ssl_authentication.enabled}}
+    {{#service.security.authorization.enabled}}
+    "TASKCFG_ALL_BROKER_COUNT": "{{brokers.count}}",
+    {{/service.security.authorization.enabled}}
+    {{/service.security.ssl_authentication.enabled}}
+    {{/service.security.transport_encryption.enabled}}
+    {{/service.security.kerberos.enabled}}
+    "BROKER_CPUS": "{{brokers.cpus}}",
+    "BROKER_MEM": "{{brokers.mem}}",
+    "BROKER_DISK_SIZE": "{{brokers.disk}}",
+    "BROKER_DISK_PATH": "{{brokers.disk_path}}",
+    "BROKER_DISK_DOCKER_VOLUME_NAME": "{{{brokers.portworx_volume_name}}}",
+    "BROKER_DISK_DOCKER_DRIVER_OPTIONS": "{{{brokers.portworx_volume_options}}}",
+    "BROKER_JAVA_HEAP": "{{brokers.heap.size}}",
+    "BROKER_PORT": "{{brokers.port}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    {{#service.security.transport_encryption.enabled}}
+    "BROKER_PORT_TLS": "{{brokers.port_tls}}",
+    "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",
+    {{#service.security.transport_encryption.allow_plaintext}}
+    "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT": "{{service.security.transport_encryption.allow_plaintext}}",
+    {{/service.security.transport_encryption.allow_plaintext}}
+
+    {{#service.security.ssl_authentication.enabled}}
+    "TASKCFG_ALL_SECURITY_SSL_AUTHENTICATION_ENABLED": "{{service.security.ssl_authentication.enabled}}",
+    {{/service.security.ssl_authentication.enabled}}
+    {{/service.security.transport_encryption.enabled}}
+
+    {{#service.security.kerberos.enabled}}
+    "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_ENABLED": "{{service.security.kerberos.enabled}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_ENABLED_FOR_ZOOKEEPER": "{{service.security.kerberos.enabled_for_zookeeper}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_PRIMARY": "{{service.security.kerberos.primary}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_REALM": "{{service.security.kerberos.realm}}",
+    {{#service.security.kerberos.debug}}
+    "TASKCFG_ALL_SECURITY_KERBEROS_DEBUG": "{{service.security.kerberos.debug}}",
+    {{/service.security.kerberos.debug}}
+    "TASKCFG_ALL_SECURITY_KERBEROS_KDC_HOSTNAME": "{{service.security.kerberos.kdc.hostname}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_KDC_PORT": "{{service.security.kerberos.kdc.port}}",
+    {{/service.security.kerberos.enabled}}
+
+    {{#service.security.authorization.enabled}}
+    "TASKCFG_ALL_SECURITY_AUTHORIZATION_ENABLED": "{{service.security.authorization.enabled}}",
+    "TASKCFG_ALL_SECURITY_AUTHORIZATION_SUPER_USERS": "{{service.security.authorization.super_users}}",
+    "TASKCFG_ALL_SECURITY_AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND": "{{service.security.authorization.allow_everyone_if_no_acl_found}}",
+    {{/service.security.authorization.enabled}}
+
+    "KAFKA_VERSION_PATH": "kafka_2.11-1.0.0",
+
+    "KAFKA_ZOOKEEPER_URI": "{{kafka.kafka_zookeeper_uri}}",
+
+    {{#kafka.kafka_advertise_host_ip}}
+    "TASKCFG_ALL_KAFKA_ADVERTISE_HOST" : "set",
+    {{/kafka.kafka_advertise_host_ip}}
+
+    "TASKCFG_ALL_KAFKA_RESERVED_BROKER_MAX_ID": "{{kafka.reserved_broker_max_id}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_COMPRESSION_CODEC": "{{kafka.offsets_topic_compression_codec}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_MIN_BYTES": "{{kafka.replica_fetch_min_bytes}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_RETRY_BACKOFF_MS": "{{kafka.controlled_shutdown_retry_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_OFFSET_CHECKPOINT_INTERVAL_MS": "{{kafka.log_flush_offset_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS": "{{kafka.offsets_topic_num_partitions}}",
+    "TASKCFG_ALL_KAFKA_MAX_CONNECTIONS_PER_IP_OVERRIDES": "{{kafka.max_connections_per_ip_overrides}}",
+    "TASKCFG_ALL_KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS": "{{kafka.leader_imbalance_check_interval_seconds}}",
+    "TASKCFG_ALL_KAFKA_INTER_BROKER_PROTOCOL_VERSION": "{{kafka.inter_broker_protocol_version}}",
+    "TASKCFG_ALL_KAFKA_LOG_MESSAGE_FORMAT_VERSION": "{{kafka.log_message_format_version}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_SOCKET_TIMEOUT_MS": "{{kafka.replica_socket_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_GROUP_MAX_SESSION_TIMEOUT_MS": "{{kafka.group_max_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_DELETE_RETENTION_MS": "{{kafka.log_cleaner_delete_retention_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_PREALLOCATE": "{{kafka.log_preallocate}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_SOCKET_RECEIVE_BUFFER_BYTES": "{{kafka.replica_socket_receive_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_OFFSET_METADATA_MAX_BYTES": "{{kafka.offset_metadata_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_MESSAGE_MAX_BYTES": "{{kafka.message_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_JITTER_HOURS": "{{kafka.log_roll_jitter_hours}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_RETENTION_CHECK_INTERVAL_MS": "{{kafka.offsets_retention_check_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_FETCH_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.fetch_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS": "{{kafka.log_retention_check_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_INDEX_INTERVAL_BYTES": "{{kafka.log_index_interval_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_NETWORK_THREADS": "{{kafka.num_network_threads}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_COMMIT_TIMEOUT_MS": "{{kafka.offsets_commit_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "{{kafka.offsets_topic_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_MAX_BYTES": "{{kafka.replica_fetch_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_CONNECTIONS_MAX_IDLE_MS": "{{kafka.connections_max_idle_ms}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_REQUEST_MAX_BYTES": "{{kafka.socket_request_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_METRICS_REPORTERS": "{{kafka.kafka_metrics_reporters}}",
+    "TASKCFG_ALL_METRIC_REPORTERS": "{{kafka.metric_reporters}}",
+    "TASKCFG_ALL_KAFKA_METRICS_NUM_SAMPLES": "{{kafka.metrics_num_samples}}",
+    "TASKCFG_ALL_KAFKA_METRICS_SAMPLE_WINDOW_MS": "{{kafka.metrics_sample_window_ms}}",
+    "TASKCFG_ALL_KAFKA_NUM_PARTITIONS": "{{kafka.num_partitions}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_LAG_TIME_MAX_MS": "{{kafka.replica_lag_time_max_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_BUFFER_LOAD_FACTOR": "{{kafka.log_cleaner_io_buffer_load_factor}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_COMMIT_REQUIRED_ACKS": "{{kafka.offsets_commit_required_acks}}",
+    "TASKCFG_ALL_KAFKA_AUTO_CREATE_TOPICS_ENABLE": "{{kafka.auto_create_topics_enable}}",
+    "TASKCFG_ALL_KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE": "{{kafka.unclean_leader_election_enable}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_BACKOFF_MS": "{{kafka.replica_fetch_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_HOURS": "{{kafka.log_roll_hours}}",
+    "TASKCFG_ALL_KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS": "{{kafka.zookeeper_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_PRODUCER_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.producer_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_GROUP_MIN_SESSION_TIMEOUT_MS": "{{kafka.group_min_session_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_INDEX_SIZE_MAX_BYTES": "{{kafka.log_index_size_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_REPLICA_FETCHERS": "{{kafka.num_replica_fetchers}}",
+    "TASKCFG_ALL_KAFKA_MIN_INSYNC_REPLICAS": "{{kafka.min_insync_replicas}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_INTERVAL_MESSAGES": "{{kafka.log_flush_interval_messages}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_SEND_BUFFER_BYTES": "{{kafka.socket_send_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_AUTO_LEADER_REBALANCE_ENABLE": "{{kafka.auto_leader_rebalance_enable}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_ENABLE": "{{kafka.log_cleaner_enable}}",
+    "TASKCFG_ALL_KAFKA_QUEUED_MAX_REQUESTS": "{{kafka.queued_max_requests}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_MAX_RETRIES": "{{kafka.controlled_shutdown_max_retries}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_LOAD_BUFFER_SIZE": "{{kafka.offsets_load_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_BYTES": "{{kafka.log_retention_bytes}}",
+    "TASKCFG_ALL_KAFKA_NUM_IO_THREADS": "{{kafka.num_io_threads}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLER_SOCKET_TIMEOUT_MS": "{{kafka.controller_socket_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_HOURS": "{{kafka.log_retention_hours}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_SCHEDULER_INTERVAL_MS": "{{kafka.log_flush_scheduler_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_RETENTION_MINUTES": "{{kafka.offsets_retention_minutes}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.quota_window_size_seconds}}",
+    "TASKCFG_ALL_KAFKA_LOG_SEGMENT_BYTES": "{{kafka.log_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_LEADER_IMBALANCE_PER_BROKER_PERCENTAGE": "{{kafka.leader_imbalance_per_broker_percentage}}",
+    "TASKCFG_ALL_KAFKA_MAX_CONNECTIONS_PER_IP": "{{kafka.max_connections_per_ip}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_DEDUPE_BUFFER_SIZE": "{{kafka.log_cleaner_dedupe_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_MIN_CLEANABLE_RATIO": "{{kafka.log_cleaner_min_cleanable_ratio}}",
+    "TASKCFG_ALL_KAFKA_ZOOKEEPER_SYNC_TIME_MS": "{{kafka.zookeeper_sync_time_ms}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_CONSUMER_DEFAULT": "{{kafka.quota_consumer_default}}",
+    "TASKCFG_ALL_KAFKA_DELETE_TOPIC_ENABLE": "{{kafka.delete_topic_enable}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANUP_POLICY": "{{kafka.log_cleanup_policy}}",
+    "TASKCFG_ALL_KAFKA_DEFAULT_REPLICATION_FACTOR": "{{kafka.default_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_NUM_RECOVERY_THREADS_PER_DATA_DIR": "{{kafka.num_recovery_threads_per_data_dir}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_BUFFER_SIZE": "{{kafka.log_cleaner_io_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_BACKGROUND_THREADS": "{{kafka.background_threads}}",
+    "TASKCFG_ALL_KAFKA_LOG_SEGMENT_DELETE_DELAY_MS": "{{kafka.log_segment_delete_delay_ms}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_WINDOW_NUM": "{{kafka.quota_window_num}}",
+    "TASKCFG_ALL_KAFKA_REQUEST_TIMEOUT_MS": "{{kafka.request_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_THREADS": "{{kafka.log_cleaner_threads}}",
+    "TASKCFG_ALL_KAFKA_QUOTA_PRODUCER_DEFAULT": "{{kafka.quota_producer_default}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_BACKOFF_MS": "{{kafka.log_cleaner_backoff_ms}}",
+    "TASKCFG_ALL_KAFKA_CONTROLLED_SHUTDOWN_ENABLE": "{{kafka.controlled_shutdown_enable}}",
+    "TASKCFG_ALL_KAFKA_SOCKET_RECEIVE_BUFFER_BYTES": "{{kafka.socket_receive_buffer_bytes}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_WAIT_MAX_MS": "{{kafka.replica_fetch_wait_max_ms}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS": "{{kafka.replica_high_watermark_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_SEGMENT_BYTES": "{{kafka.offsets_topic_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_MAX_BYTES_PER_SECOND": "{{kafka.log_cleaner_io_max_bytes_per_second}}",
+    "TASKCFG_ALL_KAFKA_COMPRESSION_TYPE": "{{kafka.compression_type}}",
+
+    {{#kafka.log_flush_interval_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_INTERVAL_MS": "{{kafka.log_flush_interval_ms}}",
+    {{/kafka.log_flush_interval_ms}}
+    {{#kafka.log_retention_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_MS": "{{kafka.log_retention_ms}}",
+    {{/kafka.log_retention_ms}}
+    {{#kafka.log_retention_minutes}}
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_MINUTES": "{{kafka.log_retention_minutes}}",
+    {{/kafka.log_retention_minutes}}
+    {{#kafka.log_roll_jitter_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_JITTER_MS": "{{kafka.log_roll_jitter_ms}}",
+    {{/kafka.log_roll_jitter_ms}}
+    {{#kafka.log_roll_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_MS": "{{kafka.log_roll_ms}}",
+    {{/kafka.log_roll_ms}}
+
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_SEGMENT_BYTES": "{{kafka.transaction_state_log_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS": "{{kafka.transaction_remove_expired_transaction_cleanup_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_QUEUED_MAX_REQUEST_BYTES": "{{kafka.queued_max_request_bytes}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_MAX_TIMEOUT_MS": "{{kafka.transaction_max_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_MIN_COMPACTION_LAG_MS": "{{kafka.log_cleaner_min_compaction_lag_ms}}",
+    "TASKCFG_ALL_KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS": "{{kafka.group_initial_rebalance_delay_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_NUM_PARTITIONS": "{{kafka.transaction_state_log_num_partitions}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_RESPONSE_MAX_BYTES": "{{kafka.replica_fetch_response_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS": "{{kafka.log_flush_start_offset_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.delete_records_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS": "{{kafka.transaction_abort_timed_out_transaction_cleanup_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_LOAD_BUFFER_SIZE": "{{kafka.transaction_state_log_load_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS": "{{kafka.transactional_id_expiration_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR": "{{kafka.transaction_state_log_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_MIN_ISR": "{{kafka.transaction_state_log_min_isr}}",
+    "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_NUM": "{{kafka.replication_quota_window_num}}",
+    "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.replication_quota_window_size_seconds}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.kafka-scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.kafka-tgz}}",
+    "{{resource.assets.uris.jre-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-kafka/100/package.json
+++ b/repo/packages/P/portworx-kafka/100/package.json
@@ -1,0 +1,26 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "1.1-0.11.0.1-bf399c5"
+  ],
+  "downgradesTo": [
+    "1.1-0.11.0.1-bf399c5"
+  ],
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx-kafka",
+  "version": "1.2-1.0.0-2b3d93b",
+  "maintainer": "support@portworx.com",
+  "description": "Apache Kafka",
+  "selected": true,
+  "framework": true,
+  "tags": [
+    "message",
+    "broker",
+    "kafka",
+    "pubsub",
+    "portworx"
+  ],
+  "preInstallNotes": "This DC/OS service is currently a beta candidate undergoing testing as part of a formal beta test program.\n\nThere may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 3 agent nodes each with: 1.0 CPU | 2048 MB MEM | 1 5000 MB Disk\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
+  "postInstallNotes": "The DC/OS Apache Kafka Service is being installed.\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/kafka.html",
+  "postUninstallNotes": "The DC/OS Apache Kafka Service is being uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required."
+}

--- a/repo/packages/P/portworx-kafka/100/resource.json
+++ b/repo/packages/P/portworx-kafka/100/resource.json
@@ -1,0 +1,63 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/bootstrap.zip",
+      "kafka-tgz": "https://downloads.mesosphere.com/kafka/assets/kafka_2.11-1.0.0.tgz",
+      "kafka-jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "kafka-scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/kafka-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/executor.zip",
+      "kafka-statsd-jar": "http://downloads.mesosphere.com/kafka/assets/kafka-statsd-metrics2-0.5.3.jar",
+      "statsd-client-jar": "http://downloads.mesosphere.com/kafka/assets/java-dogstatsd-client-2.3.jar",
+      "setup-helper-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/setup-helper.zip",
+      "zookeeper-client-jar": "http://downloads.mesosphere.com/kafka/assets/zookeeper-3.4.10.1.jar",
+      "custom-kafka-principal-jar": "http://downloads.mesosphere.com/kafka/assets/kafka-custom-principal-builder-1.0.0.jar"
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/kafka-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/kafka-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/kafka-icon-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "21d244ebb3522a80fe6307d27e63e0a7d5cd8dccb5f79d1566f22552caa42895"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "a3c738f3e4e20aa2bc136239f8fac1b003dcdf2aeb03fa65544cf5d7be60839a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "f1544b4b2ad3d755bf221f2eb52469fdb807ef8ab4b9c2692ded1bc600db1eb5"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx-kafka 1.2-1.0.0-2b3d93b (automated commit)

Description:
Source URL: https://px-dcos-dev.s3.amazonaws.com/autodelete7d/portworx-kafka/20180519-033543-HWA3VR04SrbnGKdB/stub-universe-portworx-kafka.json

Changes between revisions 1 => 100:
0 files added: []
0 files removed: []
4 files changed:

```
--- 1/config.json
+++ 100/config.json
@@ -10,14 +10,9 @@
           "type": "string",
           "default": "portworx-kafka"
         },
-        "mesos_api_version": {
-          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
-          "type": "string",
-          "default": "V0"
-        },
         "user": {
-          "type": "string",
           "description": "The user that the service will run as.",
+          "type": "string",
           "default": "root"
         },
         "service_account": {
@@ -29,11 +24,6 @@
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
           "type": "string",
           "default": ""
-        },
-        "placement_constraint": {
-          "description": "Marathon-style placement constraint for Broker nodes. Example: rack_id:LIKE:rack-foo-.*,rack_id:MAX_PER:2",
-          "type": "string",
-          "default": "hostname:MAX_PER:1"
         },
         "virtual_network_enabled": {
           "description": "Enable virtual networking",
@@ -50,16 +40,14 @@
           "type": "string",
           "default": ""
         },
-        "deploy_strategy": {
-          "description": "Deployment phase strategy. See documentation. [serial, serial-canary, parallel-canary, parallel]",
-          "type": "string",
-          "default": "serial",
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
           "enum": [
-            "serial",
-            "serial-canary",
-            "parallel-canary",
-            "parallel"
-          ]
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
         },
         "log_level": {
           "description": "The log level for the DC/OS service.",
@@ -75,6 +63,153 @@
             "ALL"
           ],
           "default": "INFO"
+        },
+        "placement_constraint": {
+          "description": "Placement constraints for broker nodes. Example: [[\"rack_id\", \"LIKE\", \"rack-foo-.*\"], [\"rack_id\", \"MAX_PER\", \"2\"]]",
+          "type": "string",
+          "default": "[[\"hostname\", \"MAX_PER\", \"1\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "deploy_strategy": {
+          "description": "Deployment phase strategy. See documentation. [serial, serial-canary, parallel-canary, parallel]",
+          "type": "string",
+          "enum": [
+            "serial",
+            "serial-canary",
+            "parallel-canary",
+            "parallel"
+          ],
+          "default": "serial"
+        },
+        "security": {
+          "description": "Kafka security settings",
+          "type": "object",
+          "allOf": [
+            {
+              "not": {
+                "properties": {
+                  "transport_encryption": {
+                    "properties": {
+                      "enabled": {
+                        "enum": [
+                          false
+                        ]
+                      }
+                    }
+                  },
+                  "ssl_authentication": {
+                    "properties": {
+                      "enabled": {
+                        "enum": [
+                          true
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": {
+            "ssl_authentication": {
+              "type": "object",
+              "description": "SSL Authn/z configuration properties.",
+              "properties": {
+                "enabled": {
+                  "description": "Enable SSL authentication.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "kerberos": {
+              "type": "object",
+              "description": "Kerberos configuration properties.",
+              "properties": {
+                "enabled": {
+                  "description": "Enable kerberos authentication.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "enabled_for_zookeeper": {
+                  "description": "Enabled Kerberos authentication for communication with Apache Zookeeper",
+                  "type": "boolean",
+                  "default": false
+                },
+                "kdc": {
+                  "description": "KDC settings for Kerberos",
+                  "type": "object",
+                  "properties": {
+                    "hostname": {
+                      "type": "string",
+                      "description": "The name or address of a host running a KDC for the realm."
+                    },
+                    "port": {
+                      "type": "integer",
+                      "description": "The port of the host running a KDC for that realm."
+                    }
+                  }
+                },
+                "primary": {
+                  "type": "string",
+                  "description": "The Kerberos primary used by Kafka tasks.  The full principal will be <service.kerberos.primary>/<mesos_dns_address>@<service.kerberos.realm>",
+                  "default": "kafka"
+                },
+                "realm": {
+                  "type": "string",
+                  "description": "The Kerberos realm used to render the principal of Kafka tasks."
+                },
+                "keytab_secret": {
+                  "type": "string",
+                  "description": "The name of the DC/OS secret storing the keytab"
+                },
+                "debug": {
+                  "type": "boolean",
+                  "description": "Turn debug Kerberos logging on or off to assist in diagnosing issues with Kerberos authentication.",
+                  "default": false
+                }
+              }
+            },
+            "transport_encryption": {
+              "type": "object",
+              "description": "Transport encryption settings",
+              "properties": {
+                "enabled": {
+                  "description": "Enable transport encryption (TLS)",
+                  "type": "boolean",
+                  "default": false
+                },
+                "allow_plaintext": {
+                  "description": "Allow plaintext alongside encrypted traffic",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "authorization": {
+              "type": "object",
+              "description": "Authorization configuration properties",
+              "properties": {
+                "enabled": {
+                  "description": "Enable authorization.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "super_users": {
+                  "description": "Semi-colon delimited list of principals. For Kerberos principals, these will be of the form User:<Kerberos-Primary>. For TLS, they will be of the form User:<CN of TLS cert> (for the TLS cert CN=test-user,OU=,O=Confluent,L=London,ST=London,C=GB, the user would be test-user)",
+                  "type": "string",
+                  "default": ""
+                },
+                "allow_everyone_if_no_acl_found": {
+                  "description": "Allow any user to perform an action if no ACL is found for the resource.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          }
         }
       },
       "required": [
@@ -111,7 +246,7 @@
           ]
         },
         "disk": {
-          "description": "Broker disk requirements in MB",
+          "description": "Broker disk requirements (only respected with persistent volumes)",
           "type": "integer",
           "default": 5000
         },
@@ -119,24 +254,29 @@
           "type": "string",
           "description": "Relative path of consistent disk",
           "default": "kafka-broker-data"
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "KafkaVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
         },
         "count": {
           "description": "Number of brokers to run",
           "type": "number",
           "default": 3
         },
-        "portworx_volume_name": {
-          "description": "Portworx volume name",
-          "type": "string",
-          "default": "KafkaVolume"
-        },
-        "portworx_volume_options": {
-          "description": "Portworx volume options. Comma separated key=value pairs",
-          "type": "string",
-          "default": ""
-        },
         "port": {
           "description": "Port for broker to listen on",
+          "type": "integer",
+          "default": 0
+        },
+        "port_tls": {
+          "description": "Port for broker to listen on for TLS connections, if the TLS is enabled",
           "type": "integer",
           "default": 0
         },
@@ -167,12 +307,12 @@
         },
         "auto_create_topics_enable": {
           "title": "auto.create.topics.enable",
-          "description": "Enables auto creation of topic on the server",
+          "description": "Enable auto creation of topic on the server",
           "type": "boolean",
           "default": true
         },
         "kafka_advertise_host_ip": {
-          "description": "Automatically configure advertised.host.name with the tasks' IP address",
+          "description": "[DEPRECATED] This configuration parameter has been deprecated and will be removed in a future release. When set to true, and no security settings are enabled, kafka's advertised.listeners property is set to PLAINTEXT://<broker-ip>:<broker-port>. When the setting is false and no security is enabled, then advertised.listeners is NOT set. When security is enabled, the advertised.listeners property will be set to broker hostnames.",
           "type": "boolean",
           "default": true
         },
@@ -186,11 +326,12 @@
           "title": "background.threads",
           "description": "The number of threads to use for various background processing tasks",
           "type": "integer",
-          "default": 10
+          "default": 10,
+          "minimum": 1
         },
         "compression_type": {
           "title": "compression.type",
-          "description": "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', lz4). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.",
+          "description": "Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.",
           "type": "string",
           "default": "producer"
         },
@@ -200,6 +341,12 @@
           "type": "boolean",
           "default": false
         },
+        "delete_records_purgatory_purge_interval_requests": {
+          "title": "delete.records.purgatory.purge.interval.requests",
+          "description": "The purge interval (in number of requests) of the delete records request purgatory",
+          "type": "integer",
+          "default": 1
+        },
         "leader_imbalance_check_interval_seconds": {
           "title": "leader.imbalance.check.interval.seconds",
           "description": "The frequency with which the partition rebalance check is triggered by the controller",
@@ -218,11 +365,17 @@
           "type": "string",
           "default": "9223372036854775807"
         },
+        "log_flush_interval_ms": {
+          "title": "log.flush.interval.ms",
+          "description": "The maximum time in ms that a message in any topic is kept in memory before flushed to disk. If not set, the value in log.flush.scheduler.interval.ms is used",
+          "type": "integer"
+        },
         "log_flush_offset_checkpoint_interval_ms": {
           "title": "log.flush.offset.checkpoint.interval.ms",
           "description": "The frequency with which we update the persistent record of the last flush which acts as the log recovery point",
           "type": "integer",
-          "default": 60000
+          "default": 60000,
+          "minimum": 0
         },
         "log_flush_scheduler_interval_ms": {
           "title": "log.flush.scheduler.interval.ms",
@@ -230,71 +383,107 @@
           "type": "string",
           "default": "9223372036854775807"
         },
+        "log_flush_start_offset_checkpoint_interval_ms": {
+          "title": "log.flush.start.offset.checkpoint.interval.ms",
+          "description": "The frequency with which we update the persistent record of log start offset",
+          "type": "integer",
+          "default": 60000,
+          "minimum": 0
+        },
         "log_retention_bytes": {
           "title": "log.retention.bytes",
           "description": "The maximum size of the log before deleting it",
           "type": "string",
           "default": "-1"
         },
+        "log_retention_ms": {
+          "title": "log.retention.ms",
+          "description": "The number of milliseconds to keep a log file before deleting it (in milliseconds), If not set, the value in log.retention.minutes is used",
+          "type": "integer"
+        },
+        "log_retention_minutes": {
+          "title": "log.retention.minutes",
+          "description": "The number of minutes to keep a log file before deleting it (in minutes), secondary to log.retention.ms property. If not set, the value in log.retention.hours is used",
+          "type": "integer"
+        },
         "log_retention_hours": {
           "title": "log.retention.hours",
           "description": "The number of hours to keep a log file before deleting it (in hours), tertiary to log.retention.ms property",
           "type": "integer",
           "default": 168
         },
+        "log_roll_ms": {
+          "title": "log.roll.ms",
+          "description": "The maximum time before a new log segment is rolled out (in milliseconds). If not set, the value in log.roll.hours is used",
+          "type": "integer"
+        },
+        "log_roll_jitter_ms": {
+          "title": "log.roll.jitter.ms",
+          "description": "The maximum jitter to subtract from logRollTimeMillis (in milliseconds). If not set, the value in log.roll.jitter.hours is used",
+          "type": "integer"
+        },
         "log_roll_hours": {
           "title": "log.roll.hours",
           "description": "The maximum time before a new log segment is rolled out (in hours), secondary to log.roll.ms property",
           "type": "integer",
-          "default": 168
+          "default": 168,
+          "minimum": 1
         },
         "log_roll_jitter_hours": {
           "title": "log.roll.jitter.hours",
           "description": "The maximum jitter to subtract from logRollTimeMillis (in hours), secondary to log.roll.jitter.ms property",
           "type": "integer",
-          "default": 0
+          "default": 0,
+          "minimum": 0
         },
         "log_segment_bytes": {
           "title": "log.segment.bytes",
           "description": "The maximum size of a single log file",
           "type": "integer",
-          "default": 1073741824
+          "default": 1073741824,
+          "minimum": 14
         },
         "log_segment_delete_delay_ms": {
           "title": "log.segment.delete.delay.ms",
           "description": "The amount of time to wait before deleting a file from the filesystem",
           "type": "integer",
-          "default": 60000
+          "default": 60000,
+          "minimum": 0
         },
         "message_max_bytes": {
           "title": "message.max.bytes",
-          "description": "The maximum size of message that the server can receive",
-          "type": "integer",
-          "default": 1000012
+          "description": "The largest record batch size allowed by Kafka. If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that the they can fetch record batches this large.\nIn the latest message format version, records are always grouped into batches for efficiency. In previous message format versions, uncompressed records are not grouped into batches and this limit only applies to a single record in that case.\nThis can be set per topic with the topic level max.message.bytes config.",
+          "type": "integer",
+          "default": 1000012,
+          "minimum": 0
         },
         "min_insync_replicas": {
           "title": "min.insync.replicas",
-          "description": "define the minimum number of replicas in ISR needed to satisfy a produce request with required.acks=-1 (or all)",
-          "type": "integer",
-          "default": 1
+          "description": "When a producer sets acks to \"all\" (or \"-1\"), min.insync.replicas specifies the minimum number of replicas that must acknowledge a write for the write to be considered successful. If this minimum cannot be met, then the producer will raise an exception (either NotEnoughReplicas or NotEnoughReplicasAfterAppend).\nWhen used together, min.insync.replicas and acks allow you to enforce greater durability guarantees. A typical scenario would be to create a topic with a replication factor of 3, set min.insync.replicas to 2, and produce with acks of \"all\". This will ensure that the producer raises an exception if a majority of replicas do not receive a write.",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
         },
         "num_io_threads": {
-          "title": "num.io.thread",
-          "description": "The number of io threads that the server uses for carrying out network requests",
-          "type": "integer",
-          "default": 8
+          "title": "num.io.threads",
+          "description": "The number of threads that the server uses for processing requests, which may include disk I/O",
+          "type": "integer",
+          "default": 8,
+          "minimum": 1
         },
         "num_network_threads": {
           "title": "num.network.threads",
-          "description": "The number of network threads that the server uses for handling network requests",
-          "type": "integer",
-          "default": 3
+          "description": "The number of threads that the server uses for receiving requests from the network and sending responses to the network",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
         },
         "num_recovery_threads_per_data_dir": {
           "title": "num.recovery.threads.per.data.dir",
           "description": "The number of threads per data directory to be used for log recovery at startup and flushing at shutdown",
           "type": "integer",
-          "default": 1
+          "default": 1,
+          "minimum": 1
         },
         "num_replica_fetchers": {
           "title": "num.replica.fetchers",
@@ -318,71 +507,85 @@
           "title": "offsets.commit.timeout.ms",
           "description": "Offset commit will be delayed until all replicas for the offsets topic receive the commit or this timeout is reached. This is similar to the producer request timeout.",
           "type": "integer",
-          "default": 5000
+          "default": 5000,
+          "minimum": 1
         },
         "offsets_load_buffer_size": {
           "title": "offsets.load.buffer.size",
           "description": "Batch size for reading from the offsets segments when loading offsets into the cache.",
           "type": "integer",
-          "default": 5242880
+          "default": 5242880,
+          "minimum": 1
         },
         "offsets_retention_check_interval_ms": {
           "title": "offsets.retention.check.interval.ms",
           "description": "Frequency at which to check for stale offsets",
           "type": "integer",
-          "default": 600000
+          "default": 600000,
+          "minimum": 1
         },
         "offsets_retention_minutes": {
           "title": "offsets.retention.minutes",
-          "description": "Log retention window in minutes for offsets topic",
-          "type": "integer",
-          "default": 1440
+          "description": "Offsets older than this retention period will be discarded",
+          "type": "integer",
+          "default": 1440,
+          "minimum": 1
         },
         "offsets_topic_compression_codec": {
           "title": "offsets.topic.compression.codec",
-          "description": "Compression codec for the offsets topic - compression may be used to achieve 'atomic' commits",
+          "description": "Compression codec for the offsets topic - compression may be used to achieve \"atomic\" commits",
           "type": "integer",
           "default": 0
         },
         "offsets_topic_num_partitions": {
           "title": "offsets.topic.num.partitions",
-          "description": "The number of partitions for the offset commit topic (should not change after deployment).",
-          "type": "integer",
-          "default": 50
+          "description": "The number of partitions for the offset commit topic (should not change after deployment)",
+          "type": "integer",
+          "default": 50,
+          "minimum": 1
         },
         "offsets_topic_replication_factor": {
           "title": "offsets.topic.replication.factor",
-          "description": "The replication factor for the offsets topic (set higher to ensure availability). To ensure that the effective replication factor of the offsets topic is the configured value, the number of alive brokers has to be at least the replication factor at the time of the first request for the offsets topic. If not, either the offsets topic creation will fail or it will get a replication factor of min(alive brokers, configured replication factor)",
-          "type": "integer",
-          "default": 3
+          "description": "The replication factor for the offsets topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
         },
         "offsets_topic_segment_bytes": {
           "title": "offsets.topic.segment.bytes",
           "description": "The offsets topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
           "type": "integer",
-          "default": 104857600
+          "default": 104857600,
+          "minimum": 1
         },
         "queued_max_requests": {
           "title": "queued.max.requests",
-          "description": "The number of queued requests allowed before blocking the network threads ",
-          "type": "integer",
-          "default": 500
+          "description": "The number of queued requests allowed before blocking the network threads",
+          "type": "integer",
+          "default": 500,
+          "minimum": 1
+        },
+        "queued_max_request_bytes": {
+          "title": "queued.max.request.bytes",
+          "description": "The number of queued bytes allowed before no more requests are read",
+          "type": "integer",
+          "default": -1
         },
         "quota_consumer_default": {
           "title": "quota.consumer.default",
-          "description": "Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second",
+          "description": "Used only when dynamic default quotas are not configured for or in Zookeeper. Any consumer distinguished by clientId/consumer group will get throttled if it fetches more bytes than this value per-second",
           "type": "string",
           "default": "9223372036854775807"
         },
         "quota_producer_default": {
           "title": "quota.producer.default",
-          "description": "Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second",
+          "description": "Used only when dynamic default quotas are not configured for , or in Zookeeper. Any producer distinguished by clientId will get throttled if it produces more bytes than this value per-second",
           "type": "string",
           "default": "9223372036854775807"
         },
         "replica_fetch_max_bytes": {
           "title": "replica.fetch.max.bytes",
-          "description": "The number of byes of messages to attempt to fetch",
+          "description": "The number of bytes of messages to attempt to fetch for each partition. This is not an absolute maximum, if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config).",
           "type": "integer",
           "default": 1048576
         },
@@ -398,6 +601,13 @@
           "type": "integer",
           "default": 500
         },
+        "replica_fetch_response_max_bytes": {
+          "title": "replica.fetch.response.max.bytes",
+          "description": "Maximum bytes expected for the entire fetch response. Records are fetched in batches, and if the first record batch in the first non-empty partition of the fetch is larger than this value, the record batch will still be returned to ensure that progress can be made. As such, this is not an absolute maximum. The maximum record batch size accepted by the broker is defined via message.max.bytes (broker config) or max.message.bytes (topic config).",
+          "type": "integer",
+          "default": 10485760,
+          "minimum": 0
+        },
         "replica_high_watermark_checkpoint_interval_ms": {
           "title": "replica.high.watermark.checkpoint.interval.ms",
           "description": "The frequency with which the high watermark is saved out to disk",
@@ -422,6 +632,20 @@
           "type": "integer",
           "default": 30000
         },
+        "replication_quota_window_num": {
+          "title": "replication.quota.window.num",
+          "description": "The number of samples to retain in memory for replication quotas",
+          "type": "integer",
+          "default": 11,
+          "minimum": 1
+        },
+        "replication_quota_window_size_seconds": {
+          "title": "replication.quota.window.size.seconds",
+          "description": "The time span of each sample for replication quotas",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
         "request_timeout_ms": {
           "title": "request.timeout.ms",
           "description": "The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.",
@@ -430,7 +654,7 @@
         },
         "socket_receive_buffer_bytes": {
           "title": "socket.receive.buffer.bytes",
-          "description": "The SO_RCVBUF buffer of the socket sever sockets",
+          "description": "The SO_RCVBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.",
           "type": "integer",
           "default": 102400
         },
@@ -438,11 +662,12 @@
           "title": "socket.request.max.bytes",
           "description": "The maximum number of bytes in a socket request",
           "type": "integer",
-          "default": 104857600
+          "default": 104857600,
+          "minimum": 1
         },
         "socket_send_buffer_bytes": {
           "title": "socket.send.buffer.bytes",
-          "description": "The SO_SNDBUF buffer of the socket sever sockets",
+          "description": "The SO_SNDBUF buffer of the socket sever sockets. If the value is -1, the OS default will be used.",
           "type": "integer",
           "default": 102400
         },
@@ -450,7 +675,7 @@
           "title": "unclean.leader.election.enable",
           "description": "Indicates whether to enable replicas not in the ISR set to be elected as leader as a last resort, even though doing so may result in data loss",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "zookeeper_session_timeout_ms": {
           "title": "zookeeper.session.timeout.ms",
@@ -502,33 +727,40 @@
         },
         "group_max_session_timeout_ms": {
           "title": "group.max.session.timeout.ms",
-          "description": "The maximum allowed session timeout for registered consumers",
+          "description": "The maximum allowed session timeout for registered consumers. Longer timeouts give consumers more time to process messages in between heartbeats at the cost of a longer time to detect failures.",
           "type": "integer",
           "default": 300000
         },
         "group_min_session_timeout_ms": {
           "title": "group.min.session.timeout.ms",
-          "description": "The minimum allowed session timeout for registered consumers",
+          "description": "The minimum allowed session timeout for registered consumers. Shorter timeouts result in quicker failure detection at the cost of more frequent consumer heartbeating, which can overwhelm broker resources.",
           "type": "integer",
           "default": 6000
+        },
+        "group_initial_rebalance_delay_ms": {
+          "title": "group.initial.rebalance.delay.ms",
+          "description": "The amount of time the group coordinator will wait for more consumers to join a new group before performing the first rebalance. A longer delay means potentially fewer rebalances, but increases the time until processing begins.",
+          "type": "integer",
+          "default": 3000
         },
         "inter_broker_protocol_version": {
           "type": "string",
           "title": "inter.broker.protocol.version",
           "description": "Specify which version of the inter-broker protocol will be used, which must align with log.message.format.version. This is typically bumped *serially* one broker at a time, *after* all brokers were upgraded to a new version. Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1, 0.10.0.0, 0.10.1.x, 0.10.2.x, 0.11.0.0. Check ApiVersion for the full list.",
-          "default": "0.11.0.0"
+          "default": "1.0"
         },
         "log_message_format_version": {
           "type": "string",
           "title": "log.message.format.version",
           "description": "Specify which version of the log message format will be used, which must align with inter.broker.protocol.version. This is a new setting as of 0.10.0.0, and should be left at 0.9.0 until clients are updated to 0.10.0.x. Similarly it should be left at 0.10.0 until all clients are updated to 0.11.0. This is typically bumped *serially* one broker at a time, *after* all inter-protocol versions are updated. Clients on earlier versions may see a performance penalty if this is increased before they've upgraded. See the latest Kafka documentation for details.",
-          "default": "0.11.0"
+          "default": "1.0"
         },
         "log_cleaner_backoff_ms": {
           "title": "log.cleaner.backoff.ms",
           "description": "The amount of time to sleep when there are no logs to clean",
           "type": "integer",
-          "default": 15000
+          "default": 15000,
+          "minimum": 0
         },
         "log_cleaner_dedupe_buffer_size": {
           "title": "log.cleaner.dedupe.buffer.size",
@@ -544,7 +776,7 @@
         },
         "log_cleaner_enable": {
           "title": "log.cleaner.enable",
-          "description": "Enable the log cleaner process to run on the server? Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.",
+          "description": "Enable the log cleaner process to run on the server. Should be enabled if using any topics with a cleanup.policy=compact including the internal offsets topic. If disabled those topics will not be compacted and continually grow in size.",
           "type": "boolean",
           "default": true
         },
@@ -558,7 +790,8 @@
           "title": "log.cleaner.io.buffer.size",
           "description": "The total memory used for log cleaner I/O buffers across all cleaner threads",
           "type": "integer",
-          "default": 524288
+          "default": 524288,
+          "minimum": 0
         },
         "log_cleaner_io_max_bytes_per_second": {
           "title": "log.cleaner.io.max.bytes.per.second",
@@ -572,29 +805,38 @@
           "type": "number",
           "default": 0.5
         },
+        "log_cleaner_min_compaction_lag_ms": {
+          "title": "log.cleaner.min.compaction.lag.ms",
+          "description": "The minimum time a message will remain uncompacted in the log. Only applicable for logs that are being compacted.",
+          "type": "integer",
+          "default": 0
+        },
         "log_cleaner_threads": {
           "title": "log.cleaner.threads",
           "description": "The number of background threads to use for log cleaning",
           "type": "integer",
-          "default": 1
+          "default": 1,
+          "minimum": 0
         },
         "log_cleanup_policy": {
           "type": "string",
           "title": "log.cleanup.policy",
-          "description": "The default cleanup policy for segments beyond the retention window, must be either 'delete' or 'compact'",
+          "description": "The default cleanup policy for segments beyond the retention window. A comma separated list of valid policies. Valid policies are: \"delete\" and \"compact\"",
           "default": "delete"
         },
         "log_index_interval_bytes": {
           "title": "log.index.interval.bytes",
           "description": "The interval with which we add an entry to the offset index",
           "type": "integer",
-          "default": 4096
+          "default": 4096,
+          "minimum": 0
         },
         "log_index_size_max_bytes": {
           "title": "log.index.size.max.bytes",
           "description": "The maximum size in bytes of the offset index",
           "type": "integer",
-          "default": 10485760
+          "default": 10485760,
+          "minimum": 4
         },
         "log_preallocate": {
           "title": "log.preallocate",
@@ -606,13 +848,15 @@
           "title": "log.retention.check.interval.ms",
           "description": "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion",
           "type": "integer",
-          "default": 300000
+          "default": 300000,
+          "minimum": 1
         },
         "max_connections_per_ip": {
           "title": "max.connections.per.ip",
-          "description": "mum number of connections we allow from each ip address",
-          "type": "integer",
-          "default": 2147483647
+          "description": "The maximum number of connections we allow from each ip address",
+          "type": "integer",
+          "default": 2147483647,
+          "minimum": 1
         },
         "max_connections_per_ip_overrides": {
           "type": "string",
@@ -624,7 +868,8 @@
           "title": "num.partitions",
           "description": "The default number of log partitions per topic",
           "type": "integer",
-          "default": 1
+          "default": 1,
+          "minimum": 1
         },
         "producer_purgatory_purge_interval_requests": {
           "title": "producer.purgatory.purge.interval.requests",
@@ -636,13 +881,15 @@
           "title": "replica.fetch.backoff.ms",
           "description": "The amount of time to sleep when fetch partition error occurs.",
           "type": "integer",
-          "default": 1000
+          "default": 1000,
+          "minimum": 0
         },
         "reserved_broker_max_id": {
           "title": "reserved.broker.max.id",
           "description": "Max number that can be used for a broker.id",
           "type": "integer",
-          "default": 1000
+          "default": 1000,
+          "minimum": 0
         },
         "kafka_metrics_reporters": {
           "title": "kafka.metric.reporters",
@@ -660,25 +907,92 @@
           "title": "metrics.num.samples",
           "description": "The number of samples maintained to compute metrics.",
           "type": "integer",
-          "default": 2
+          "default": 2,
+          "minimum": 1
         },
         "metrics_sample_window_ms": {
           "title": "metrics.sample.window.ms",
-          "description": "The number of samples maintained to compute metrics.",
-          "type": "integer",
-          "default": 30000
+          "description": "The window of time a metrics sample is computed over.",
+          "type": "integer",
+          "default": 30000,
+          "minimum": 1
         },
         "quota_window_num": {
           "title": "quota.window.num",
-          "description": "The number of samples to retain in memory",
-          "type": "integer",
-          "default": 11
+          "description": "The number of samples to retain in memory for client quotas",
+          "type": "integer",
+          "default": 11,
+          "minimum": 1
         },
         "quota_window_size_seconds": {
           "title": "quota.window.size.seconds",
-          "description": "The time span of each sample",
-          "type": "integer",
-          "default": 1
+          "description": "The time span of each sample for client quotas",
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
+        "transaction_state_log_segment_bytes": {
+          "title": "transaction.state.log.segment.bytes",
+          "description": "The transaction topic segment bytes should be kept relatively small in order to facilitate faster log compaction and cache loads",
+          "type": "integer",
+          "default": 104857600,
+          "minimum": 1
+        },
+        "transaction_remove_expired_transaction_cleanup_interval_ms": {
+          "title": "transaction.remove.expired.transaction.cleanup.interval.ms",
+          "description": "The interval at which to remove transactions that have expired due to transactional.id.expiration.ms passing",
+          "type": "integer",
+          "default": 3600000,
+          "minimum": 1
+        },
+        "transaction_max_timeout_ms": {
+          "title": "transaction.max.timeout.ms",
+          "description": "The maximum allowed timeout for transactions. If a client\u2019s requested transaction time exceed this, then the broker will return an error in InitProducerIdRequest. This prevents a client from too large of a timeout, which can stall consumers reading from topics included in the transaction.",
+          "type": "integer",
+          "default": 900000,
+          "minimum": 1
+        },
+        "transaction_state_log_num_partitions": {
+          "title": "transaction.state.log.num.partitions",
+          "description": "The number of partitions for the transaction topic (should not change after deployment).",
+          "type": "integer",
+          "default": 50,
+          "minimum": 1
+        },
+        "transaction_abort_timed_out_transaction_cleanup_interval_ms": {
+          "title": "transaction.abort.timed.out.transaction.cleanup.interval.ms",
+          "description": "The interval at which to rollback transactions that have timed out",
+          "type": "integer",
+          "default": 60000,
+          "minimum": 1
+        },
+        "transaction_state_log_load_buffer_size": {
+          "title": "transaction.state.log.load.buffer.size",
+          "description": "Batch size for reading from the transaction log segments when loading producer ids and transactions into the cache.",
+          "type": "integer",
+          "default": 5242880,
+          "minimum": 1
+        },
+        "transaction_state_log_replication_factor": {
+          "title": "transaction.state.log.replication.factor",
+          "description": "The replication factor for the transaction topic (set higher to ensure availability). Internal topic creation will fail until the cluster size meets this replication factor requirement.",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
+        },
+        "transaction_state_log_min_isr": {
+          "title": "transaction.state.log.min.isr",
+          "description": "Overridden min.insync.replicas config for the transaction topic.",
+          "type": "integer",
+          "default": 2,
+          "minimum": 1
+        },
+        "transactional_id_expiration_ms": {
+          "title": "transactional.id.expiration.ms",
+          "description": "The maximum amount of time in ms that the transaction coordinator will wait before proactively expire a producer's transactional id without receiving any transaction status updates from it.",
+          "type": "integer",
+          "default": 604800000,
+          "minimum": 1
         },
         "zookeeper_sync_time_ms": {
           "title": "zookeeper.sync.time.ms",
--- 1/marathon.json.mustache
+++ 100/marathon.json.mustache
@@ -3,8 +3,8 @@
   "cpus": 1.0,
   "mem": 1024,
   "instances": 1,
-  "user":"{{service.user}}",
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./kafka-scheduler/bin/kafka ./kafka-scheduler/svc.yml",
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./kafka-scheduler/bin/kafka ./kafka-scheduler/svc.yml",
   "labels": {
     "DCOS_COMMONS_API_VERSION": "v1",
     "DCOS_COMMONS_UNINSTALL": "true",
@@ -22,15 +22,15 @@
   },
   {{/service.service_account_secret}}
   "env": {
+    "PACKAGE_NAME": "portworx-kafka",
+    "PACKAGE_VERSION": "1.2-1.0.0-2b3d93b",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1526700944908",
+    "PACKAGE_BUILD_TIME_STR": "Sat May 19 2018 03:35:44 +0000",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
-    {{#brokers.kill_grace_period}}
     "BROKER_KILL_GRACE_PERIOD": "{{brokers.kill_grace_period}}",
-    {{/brokers.kill_grace_period}}
-    "CMD_PREFIX": "{{service.cmd_prefix}}",
-    "SECRET_NAME": "{{service.secret_name}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
@@ -40,10 +40,23 @@
     "MESOS_API_VERSION": "{{service.mesos_api_version}}",
     "KAFKA_STATSD_URI": "{{resource.assets.uris.kafka-statsd-jar}}",
     "CLIENT_STATSD_URI": "{{resource.assets.uris.statsd-client-jar}}",
-
-    "PLACEMENT_CONSTRAINTS": "{{service.placement_constraint}}",
+    "SETUP_HELPER_URI": "{{resource.assets.uris.setup-helper-zip}}",
+    "ZOOKEEPER_CLIENT_URI": "{{resource.assets.uris.zookeeper-client-jar}}",
+    "CUSTOM_KAFKA_PRINCIPAL_URI": "{{resource.assets.uris.custom-kafka-principal-jar}}",
+    "KAFKA_VERSION": "2.11-1.0.0",
+
+    "PLACEMENT_CONSTRAINTS": "{{{service.placement_constraint}}}",
     "DEPLOY_STRATEGY":"{{service.deploy_strategy}}",
     "BROKER_COUNT": "{{brokers.count}}",
+    {{^service.security.kerberos.enabled}}
+    {{#service.security.transport_encryption.enabled}}
+    {{#service.security.ssl_authentication.enabled}}
+    {{#service.security.authorization.enabled}}
+    "TASKCFG_ALL_BROKER_COUNT": "{{brokers.count}}",
+    {{/service.security.authorization.enabled}}
+    {{/service.security.ssl_authentication.enabled}}
+    {{/service.security.transport_encryption.enabled}}
+    {{/service.security.kerberos.enabled}}
     "BROKER_CPUS": "{{brokers.cpus}}",
     "BROKER_MEM": "{{brokers.mem}}",
     "BROKER_DISK_SIZE": "{{brokers.disk}}",
@@ -55,8 +68,9 @@
 
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
 
     {{#service.virtual_network_enabled}}
@@ -65,16 +79,38 @@
     "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
     {{/service.virtual_network_enabled}}
 
-    {{#service.tls}}
+    {{#service.security.transport_encryption.enabled}}
     "BROKER_PORT_TLS": "{{brokers.port_tls}}",
-    "TASKCFG_ALL_KAFKA_ENABLE_TLS": "{{service.tls}}",
-    {{#service.tls_allow_plaintext}}
-    "TASKCFG_ALL_KAFKA_ALLOW_PLAINTEXT": "{{service.tls_allow_plaintext}}",
-    {{/service.tls_allow_plaintext}}
-    {{/service.tls}}
-
-    "CONFIG_TEMPLATE_PATH": "kafka-scheduler",
-    "KAFKA_VERSION_PATH": "kafka_2.11-0.11.0.1",
+    "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",
+    {{#service.security.transport_encryption.allow_plaintext}}
+    "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ALLOW_PLAINTEXT": "{{service.security.transport_encryption.allow_plaintext}}",
+    {{/service.security.transport_encryption.allow_plaintext}}
+
+    {{#service.security.ssl_authentication.enabled}}
+    "TASKCFG_ALL_SECURITY_SSL_AUTHENTICATION_ENABLED": "{{service.security.ssl_authentication.enabled}}",
+    {{/service.security.ssl_authentication.enabled}}
+    {{/service.security.transport_encryption.enabled}}
+
+    {{#service.security.kerberos.enabled}}
+    "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_ENABLED": "{{service.security.kerberos.enabled}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_ENABLED_FOR_ZOOKEEPER": "{{service.security.kerberos.enabled_for_zookeeper}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_PRIMARY": "{{service.security.kerberos.primary}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_REALM": "{{service.security.kerberos.realm}}",
+    {{#service.security.kerberos.debug}}
+    "TASKCFG_ALL_SECURITY_KERBEROS_DEBUG": "{{service.security.kerberos.debug}}",
+    {{/service.security.kerberos.debug}}
+    "TASKCFG_ALL_SECURITY_KERBEROS_KDC_HOSTNAME": "{{service.security.kerberos.kdc.hostname}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_KDC_PORT": "{{service.security.kerberos.kdc.port}}",
+    {{/service.security.kerberos.enabled}}
+
+    {{#service.security.authorization.enabled}}
+    "TASKCFG_ALL_SECURITY_AUTHORIZATION_ENABLED": "{{service.security.authorization.enabled}}",
+    "TASKCFG_ALL_SECURITY_AUTHORIZATION_SUPER_USERS": "{{service.security.authorization.super_users}}",
+    "TASKCFG_ALL_SECURITY_AUTHORIZATION_ALLOW_EVERYONE_IF_NO_ACL_FOUND": "{{service.security.authorization.allow_everyone_if_no_acl_found}}",
+    {{/service.security.authorization.enabled}}
+
+    "KAFKA_VERSION_PATH": "kafka_2.11-1.0.0",
 
     "KAFKA_ZOOKEEPER_URI": "{{kafka.kafka_zookeeper_uri}}",
 
@@ -167,10 +203,43 @@
     "TASKCFG_ALL_KAFKA_REPLICA_HIGH_WATERMARK_CHECKPOINT_INTERVAL_MS": "{{kafka.replica_high_watermark_checkpoint_interval_ms}}",
     "TASKCFG_ALL_KAFKA_OFFSETS_TOPIC_SEGMENT_BYTES": "{{kafka.offsets_topic_segment_bytes}}",
     "TASKCFG_ALL_KAFKA_LOG_CLEANER_IO_MAX_BYTES_PER_SECOND": "{{kafka.log_cleaner_io_max_bytes_per_second}}",
-    "TASKCFG_ALL_KAFKA_COMPRESSION_TYPE": "{{kafka.compression_type}}"
+    "TASKCFG_ALL_KAFKA_COMPRESSION_TYPE": "{{kafka.compression_type}}",
+
+    {{#kafka.log_flush_interval_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_INTERVAL_MS": "{{kafka.log_flush_interval_ms}}",
+    {{/kafka.log_flush_interval_ms}}
+    {{#kafka.log_retention_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_MS": "{{kafka.log_retention_ms}}",
+    {{/kafka.log_retention_ms}}
+    {{#kafka.log_retention_minutes}}
+    "TASKCFG_ALL_KAFKA_LOG_RETENTION_MINUTES": "{{kafka.log_retention_minutes}}",
+    {{/kafka.log_retention_minutes}}
+    {{#kafka.log_roll_jitter_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_JITTER_MS": "{{kafka.log_roll_jitter_ms}}",
+    {{/kafka.log_roll_jitter_ms}}
+    {{#kafka.log_roll_ms}}
+    "TASKCFG_ALL_KAFKA_LOG_ROLL_MS": "{{kafka.log_roll_ms}}",
+    {{/kafka.log_roll_ms}}
+
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_SEGMENT_BYTES": "{{kafka.transaction_state_log_segment_bytes}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_REMOVE_EXPIRED_TRANSACTION_CLEANUP_INTERVAL_MS": "{{kafka.transaction_remove_expired_transaction_cleanup_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_QUEUED_MAX_REQUEST_BYTES": "{{kafka.queued_max_request_bytes}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_MAX_TIMEOUT_MS": "{{kafka.transaction_max_timeout_ms}}",
+    "TASKCFG_ALL_KAFKA_LOG_CLEANER_MIN_COMPACTION_LAG_MS": "{{kafka.log_cleaner_min_compaction_lag_ms}}",
+    "TASKCFG_ALL_KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS": "{{kafka.group_initial_rebalance_delay_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_NUM_PARTITIONS": "{{kafka.transaction_state_log_num_partitions}}",
+    "TASKCFG_ALL_KAFKA_REPLICA_FETCH_RESPONSE_MAX_BYTES": "{{kafka.replica_fetch_response_max_bytes}}",
+    "TASKCFG_ALL_KAFKA_LOG_FLUSH_START_OFFSET_CHECKPOINT_INTERVAL_MS": "{{kafka.log_flush_start_offset_checkpoint_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_DELETE_RECORDS_PURGATORY_PURGE_INTERVAL_REQUESTS": "{{kafka.delete_records_purgatory_purge_interval_requests}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_ABORT_TIMED_OUT_TRANSACTION_CLEANUP_INTERVAL_MS": "{{kafka.transaction_abort_timed_out_transaction_cleanup_interval_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_LOAD_BUFFER_SIZE": "{{kafka.transaction_state_log_load_buffer_size}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTIONAL_ID_EXPIRATION_MS": "{{kafka.transactional_id_expiration_ms}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR": "{{kafka.transaction_state_log_replication_factor}}",
+    "TASKCFG_ALL_KAFKA_TRANSACTION_STATE_LOG_MIN_ISR": "{{kafka.transaction_state_log_min_isr}}",
+    "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_NUM": "{{kafka.replication_quota_window_num}}",
+    "TASKCFG_ALL_KAFKA_REPLICATION_QUOTA_WINDOW_SIZE_SECONDS": "{{kafka.replication_quota_window_size_seconds}}"
   },
   "uris": [
-    "{{resource.assets.uris.executor-zip}}",
     "{{resource.assets.uris.bootstrap-zip}}",
     "{{resource.assets.uris.kafka-scheduler-zip}}",
     "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
@@ -183,17 +252,8 @@
   },
   "healthChecks": [
     {
-      "protocol": "HTTP",
-      "path": "/v1/plans/deploy",
-      "gracePeriodSeconds": 900,
-      "intervalSeconds": 30,
-      "portIndex": 0,
-      "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 0
-    },
-    {
-      "protocol": "HTTP",
-      "path": "/v1/plans/recovery",
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,
--- 1/package.json
+++ 100/package.json
@@ -1,14 +1,18 @@
 {
-  "description": "Apache Kafka",
-  "framework": true,
-  "maintainer": "support@portworx.com",
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "1.1-0.11.0.1-bf399c5"
+  ],
+  "downgradesTo": [
+    "1.1-0.11.0.1-bf399c5"
+  ],
   "minDcosReleaseVersion": "1.9",
   "name": "portworx-kafka",
-  "packagingVersion": "4.0",
-  "postInstallNotes": "DC/OS Apache Kafka Service is being installed.\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/kafka.html",
-  "postUninstallNotes": "DC/OS Apache Kafka Service is being uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
-  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 2048 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
-  "selected": false,
+  "version": "1.2-1.0.0-2b3d93b",
+  "maintainer": "support@portworx.com",
+  "description": "Apache Kafka",
+  "selected": true,
+  "framework": true,
   "tags": [
     "message",
     "broker",
@@ -16,5 +20,7 @@
     "pubsub",
     "portworx"
   ],
-  "version": "1.1-0.11.0.1-bf399c5"
-}
+  "preInstallNotes": "This DC/OS service is currently a beta candidate undergoing testing as part of a formal beta test program.\n\nThere may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 3 agent nodes each with: 1.0 CPU | 2048 MB MEM | 1 5000 MB Disk\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
+  "postInstallNotes": "The DC/OS Apache Kafka Service is being installed.\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/kafka.html",
+  "postUninstallNotes": "The DC/OS Apache Kafka Service is being uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required."
+}--- 1/resource.json
+++ 100/resource.json
@@ -1,21 +1,24 @@
 {
   "assets": {
     "uris": {
-      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
-      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.1-0.11.0.1-bf399c5/bootstrap.zip",
-      "kafka-tgz": "https://downloads.mesosphere.com/kafka/assets/kafka_2.11-0.11.0.1.tgz",
-      "kafka-jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
-      "kafka-scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.1-0.11.0.1-bf399c5/kafka-scheduler.zip",
-      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.1-0.11.0.1-bf399c5/executor.zip",
-      "kafka-statsd-jar": "https://downloads.mesosphere.com/kafka/assets/kafka-statsd-metrics2-0.5.3.jar",
-      "statsd-client-jar": "https://downloads.mesosphere.com/kafka/assets/java-dogstatsd-client-2.3.jar"
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/bootstrap.zip",
+      "kafka-tgz": "https://downloads.mesosphere.com/kafka/assets/kafka_2.11-1.0.0.tgz",
+      "kafka-jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "kafka-scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/kafka-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/executor.zip",
+      "kafka-statsd-jar": "http://downloads.mesosphere.com/kafka/assets/kafka-statsd-metrics2-0.5.3.jar",
+      "statsd-client-jar": "http://downloads.mesosphere.com/kafka/assets/java-dogstatsd-client-2.3.jar",
+      "setup-helper-zip": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/setup-helper.zip",
+      "zookeeper-client-jar": "http://downloads.mesosphere.com/kafka/assets/zookeeper-3.4.10.1.jar",
+      "custom-kafka-principal-jar": "http://downloads.mesosphere.com/kafka/assets/kafka-custom-principal-builder-1.0.0.jar"
     }
   },
   "images": {
-    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/portworx-kafka-icon-small.png",
-    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/portworx-kafka-icon-medium.png",
-    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/portworx-kafka-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/kafka-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/kafka-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/kafka-icon-large.png"
   },
   "cli": {
     "binaries": {
@@ -24,11 +27,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "27eb3e3a9b441ad2f10adb076ce9df52c0b464e9e27c7851e30d3dac6e541fc9"
+              "value": "21d244ebb3522a80fe6307d27e63e0a7d5cd8dccb5f79d1566f22552caa42895"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.1-0.11.0.1-bf399c5/dcos-portworx-kafka-darwin"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -36,11 +39,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "513d2a1b88a778f6a30d598db79dca43a7fdca3b5e0e1d392a7b53443244e25c"
+              "value": "a3c738f3e4e20aa2bc136239f8fac1b003dcdf2aeb03fa65544cf5d7be60839a"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.1-0.11.0.1-bf399c5/dcos-portworx-kafka-linux"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -48,11 +51,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "7770aa05f671846c6d215b81248be2b29a6948c2bc20facdf2e6b65a9485e1c7"
+              "value": "f1544b4b2ad3d755bf221f2eb52469fdb807ef8ab4b9c2692ded1bc600db1eb5"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.1-0.11.0.1-bf399c5/dcos-portworx-kafka.exe"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-kafka/assets/1.2-1.0.0-2b3d93b/dcos-service-cli.exe"
         }
       }
     }
```
