### PR TITLE
Release portworx-couchdb 1.2-2.1.1 (automated commit)



### DIFF
--- a/repo/packages/P/portworx-couchdb/100/config.json
+++ b/repo/packages/P/portworx-couchdb/100/config.json
@@ -1,0 +1,190 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS CouchDB service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the CouchDB service instance",
+          "type": "string",
+          "default": "portworx-couchdb"
+        },
+        "user": {
+          "title": "User",
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "node": {
+      "description": "DC/OS CouchDB node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of CouchDB nodes in the cluster",
+          "type": "integer",
+          "default": 3,
+          "minimum": 1
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Number of cpu shares allocated to the CouchDB process",
+          "type": "number",
+          "default": 0.5
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Amount of memory allocated to the CouchDB process (in MB)",
+          "type": "integer",
+          "default": 2048
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Amount of disk space allocated to CouchDB (in MB)",
+          "type": "integer",
+          "default": 10240
+        },
+        "portworx_volume_name": {
+          "title": "Portworx volume name",
+          "description": "Name of the volume used with Portworx driver",
+          "type": "string",
+          "default": "CouchDBVolume"
+        },
+        "portworx_volume_options": {
+          "title": "Portworx volume options",
+          "description": "Comma separated key=value pairs of options passed to Portworx driver",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "portworx_volume_name"
+      ]
+    },
+    "couchdb": {
+      "description": "CouchDB configuration properties",
+      "type": "object",
+      "properties": {
+        "couchdb_image": {
+          "title": "CouchDB image name",
+          "description": "CouchDB image to use for the cluster",
+          "type": "string",
+          "default": "couchdb:2.1.1"
+        },
+        "cluster_port": {
+          "title": "Cluster port",
+          "description": "Port used by clients to talk to CouchDB",
+          "type": "integer",
+          "default": 5984
+        },
+        "node_local_port": {
+          "title": "Node local port",
+          "description": "Port used only for maintenance and administrative tasks",
+          "type": "integer",
+          "default": 5986
+        },
+        "user": {
+          "title": "Admin user",
+          "description": "Admin user to configure CouchDB",
+          "type": "string",
+          "default": "admin"
+        },
+        "password": {
+          "title": "Admin password",
+          "description": "Password of the CouchDB admin user",
+          "type": "string",
+          "default": "password"
+        },
+        "cookie": {
+          "title": "Cookie",
+          "description": "Cookie used to form the Erlang cluster",
+          "type": "string",
+          "default": "couchdbcookie"
+        },
+        "secret": {
+          "title": "Secret",
+          "description": "Secret token used for proxy and cookie authentication",
+          "type": "string",
+          "default": "couchdbsecret"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "cluster_port",
+        "node_local_port",
+        "user",
+        "password",
+        "cookie"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx-couchdb/100/marathon.json.mustache
+++ b/repo/packages/P/portworx-couchdb/100/marathon.json.mustache
@@ -1,0 +1,100 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 0.5,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./couchdb-scheduler/bin/couchdb ./couchdb-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "PACKAGE_NAME": "portworx-couchdb",
+    "PACKAGE_VERSION": "1.2-2.1.1",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1526948750141",
+    "PACKAGE_BUILD_TIME_STR": "Tue May 22 2018 00:25:50 +0000",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    "COUCHDB_CPUS": "{{node.cpus}}",
+    "COUCHDB_MEM_MB": "{{node.mem}}",
+    "COUCHDB_DISK_MB": "{{node.disk}}",
+    "COUCHDB_DOCKER_VOLUME_NAME": "{{{node.portworx_volume_name}}}",
+    "COUCHDB_DOCKER_DRIVER_OPTIONS": "{{{node.portworx_volume_options}}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+
+    "COUCHDB_PORT": "{{couchdb.cluster_port}}",
+    "COUCHDB_NODE_PORT": "{{couchdb.node_local_port}}",
+    "COUCHDB_USER": "{{couchdb.user}}",
+    "COUCHDB_PASSWORD": "{{couchdb.password}}",
+    "COUCHDB_COOKIE": "{{couchdb.cookie}}",
+    "COUCHDB_SECRET": "{{couchdb.secret}}",
+
+    "COUCHDB_DOCKER_IMAGE": "{{couchdb.couchdb_image}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "SCHEDULER_URI": "{{resource.assets.uris.scheduler-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-couchdb/100/package.json
+++ b/repo/packages/P/portworx-couchdb/100/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "1.1-2.1.1-56b7afa"
+  ],
+  "downgradesTo": [
+    "1.1-2.1.1-56b7afa"
+  ],
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx-couchdb",
+  "version": "1.2-2.1.1",
+  "maintainer": "support@portworx.com",
+  "description": "Apache CouchDB backed by Portworx volumes",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "couchdb",
+    "portworx"
+  ],
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.5 CPU | 2048 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
+  "postInstallNotes": "DC/OS portworx-couchdb is being installed!\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/frameworks.html",
+  "postUninstallNotes": "DC/OS portworx-couchdb has been uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required."
+}

--- a/repo/packages/P/portworx-couchdb/100/resource.json
+++ b/repo/packages/P/portworx-couchdb/100/resource.json
@@ -1,0 +1,61 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/couchdb-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/bootstrap.zip"
+    },
+    "container": {
+      "docker": {
+        "couchdb": "couchdb:2.1.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-couchdb/img/couchdb-small.png",
+    "icon-medium": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-couchdb/img/couchdb-medium.png",
+    "icon-large": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-couchdb/img/couchdb-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "86dbc805bbcc861a67a32b4e61a1c7278c96da862dd30874675120826e0692f9"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "90a1fae8248bc8a161c9e9e1c1eec147237781d6d72ac5cbc954a5cc98c4cc35"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "8fcc26ab186e8561daf0b25751a4a172ad50c897ecf6f269a1c1089db1c5857e"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx-couchdb 1.2-2.1.1 (automated commit)

Description:
Source URL: https://px-dcos-dev.s3.amazonaws.com/autodelete7d/portworx-couchdb/20180522-002548-vtKxStuuM27nFHtS/stub-universe-portworx-couchdb.json

Changes between revisions 0 => 100:
0 files added: []
0 files removed: []
4 files changed:

```
--- 0/config.json
+++ 100/config.json
@@ -42,6 +42,15 @@
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
           "type": "string",
           "default": ""
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
         },
         "log_level": {
           "description": "The log level for the DC/OS service.",
--- 0/marathon.json.mustache
+++ 100/marathon.json.mustache
@@ -3,7 +3,7 @@
   "cpus": 0.5,
   "mem": 1024,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./couchdb-scheduler/bin/couchdb ./couchdb-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./couchdb-scheduler/bin/couchdb ./couchdb-scheduler/svc.yml",
   "labels": {
     "DCOS_COMMONS_API_VERSION": "v1",
     "DCOS_COMMONS_UNINSTALL": "true",
@@ -21,6 +21,12 @@
   },
   {{/service.service_account_secret}}
   "env": {
+    "PACKAGE_NAME": "portworx-couchdb",
+    "PACKAGE_VERSION": "1.2-2.1.1",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1526948750141",
+    "PACKAGE_BUILD_TIME_STR": "Tue May 22 2018 00:25:50 +0000",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
@@ -43,8 +49,9 @@
 
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
 
     "COUCHDB_PORT": "{{couchdb.cluster_port}}",
@@ -56,11 +63,13 @@
 
     "COUCHDB_DOCKER_IMAGE": "{{couchdb.couchdb_image}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
     "SCHEDULER_URI": "{{resource.assets.uris.scheduler-zip}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
   },
   "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
     "{{resource.assets.uris.jre-tar-gz}}",
     "{{resource.assets.uris.scheduler-zip}}",
     "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
@@ -71,17 +80,8 @@
   },
   "healthChecks": [
     {
-      "protocol": "HTTP",
-      "path": "/v1/plans/deploy",
-      "gracePeriodSeconds": 900,
-      "intervalSeconds": 30,
-      "portIndex": 0,
-      "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 0
-    },
-    {
-      "protocol": "HTTP",
-      "path": "/v1/plans/recovery",
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
       "gracePeriodSeconds": 900,
       "intervalSeconds": 30,
       "portIndex": 0,
--- 0/package.json
+++ 100/package.json
@@ -1,17 +1,23 @@
 {
-  "description": "Apache CouchDB backed by Portworx volumes",
-  "framework": true,
-  "maintainer": "support@portworx.com",
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "1.1-2.1.1-56b7afa"
+  ],
+  "downgradesTo": [
+    "1.1-2.1.1-56b7afa"
+  ],
   "minDcosReleaseVersion": "1.9",
   "name": "portworx-couchdb",
-  "packagingVersion": "4.0",
-  "postInstallNotes": "DC/OS portworx-couchdb is being installed!\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/frameworks.html",
-  "postUninstallNotes": "DC/OS portworx-couchdb has been uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
-  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.5 CPU | 2048 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
+  "version": "1.2-2.1.1",
+  "maintainer": "support@portworx.com",
+  "description": "Apache CouchDB backed by Portworx volumes",
   "selected": false,
+  "framework": true,
   "tags": [
     "couchdb",
     "portworx"
   ],
-  "version": "1.1-2.1.1-56b7afa"
-}
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.5 CPU | 2048 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
+  "postInstallNotes": "DC/OS portworx-couchdb is being installed!\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/frameworks.html",
+  "postUninstallNotes": "DC/OS portworx-couchdb has been uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required."
+}--- 0/resource.json
+++ 100/resource.json
@@ -1,10 +1,11 @@
 {
   "assets": {
     "uris": {
-      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
-      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/couchdb-scheduler.zip",
-      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/executor.zip"
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/couchdb-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/bootstrap.zip"
     },
     "container": {
       "docker": {
@@ -24,11 +25,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "c7191c0f913533ff3d978d7db2e82f35bb1e52e87f7f2f48f6f4eec93cc8f2ef"
+              "value": "86dbc805bbcc861a67a32b4e61a1c7278c96da862dd30874675120826e0692f9"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/dcos-portworx-couchdb-darwin"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -36,11 +37,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "ade0c8aeabc998fcda49b73b102a3c784840669c022d3e974705ec284467b590"
+              "value": "90a1fae8248bc8a161c9e9e1c1eec147237781d6d72ac5cbc954a5cc98c4cc35"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/dcos-portworx-couchdb-linux"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -48,11 +49,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "43ae4087bf5735a77ff9d2e7e2af1b2a46cfc730af6382df6c24bf37963db8b7"
+              "value": "8fcc26ab186e8561daf0b25751a4a172ad50c897ecf6f269a1c1089db1c5857e"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.1-2.1.1-56b7afa/dcos-portworx-couchdb.exe"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-couchdb/assets/1.2-2.1.1/dcos-service-cli.exe"
         }
       }
     }
```
