### PR TITLE
Release portworx-percona-mongo 1.2.2-3.4.14 (automated commit)



### DIFF
--- a/repo/packages/P/portworx-percona-mongo/0/config.json
+++ b/repo/packages/P/portworx-percona-mongo/0/config.json
@@ -1,0 +1,891 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "portworx-percona-mongo"
+        },
+        "user": {
+          "title": "User",
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "principal": {
+          "title": "Custom principal (optional)",
+          "description": "The principal for the service instance, or empty to use the default.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_networks": {
+          "description": "Enable DC/OS Virtual Networking",
+          "type": "boolean",
+          "default": false
+        },
+        "secret_name": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        },
+        "mesos_api_version": {
+          "description": "The Mesos API version to be used by the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        }
+      },
+      "required": [
+        "name",
+        "user",
+        "mesos_api_version"
+      ]
+    },
+    "mongodb": {
+      "description": "MongoDB server node configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "MongoDB server node cpu requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "description": "MongoDB server node mem requirements",
+          "type": "integer",
+          "default": 1024,
+          "minimum": 1024
+        },
+        "disk": {
+          "description": "MongoDB server node disk requirements, in megabytes",
+          "type": "integer",
+          "default": 10240
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "PerconaMongoDB"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "count": {
+          "description": "Number of MongoDB replica set members/nodes to run. 1, 3, 5 or 7 node count is possible",
+          "type": "integer",
+          "enum": [
+            1,
+            3,
+            5,
+            7
+          ],
+          "default": 3
+        },
+        "replicaSetName": {
+          "title": "replication.replicaSetName",
+          "description": "Name of the MongoDB ReplicaSet",
+          "type": "string",
+          "default": "rs"
+        },
+        "port": {
+          "description": "MongoDB server listening port. Must be a number between 1024 and 65535",
+          "type": "integer",
+          "default": 27017,
+          "minimum": 1025
+        },
+        "nodePlacement": {
+          "title": "MongoDB Node Placement constraint",
+          "description": "Marathon-style constraint for MongoDB server nodes (use empty string to override the default hostname UNIQUE behavior)",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]"
+        },
+        "backupUser": {
+          "description": "MongoDB backup user name",
+          "type": "string",
+          "default": "backup"
+        },
+        "backupPassword": {
+          "description": "MongoDB backup password",
+          "type": "string",
+          "default": "backuppassword"
+        },
+        "userAdminUser": {
+          "description": "MongoDB userAdmin user name",
+          "type": "string",
+          "default": "useradmin"
+        },
+        "userAdminPassword": {
+          "description": "MongoDB userAdmin password",
+          "type": "string",
+          "default": "useradminpassword"
+        },
+        "clusterAdminUser": {
+          "description": "MongoDB clusterAdmin user name",
+          "type": "string",
+          "default": "clusteradmin"
+        },
+        "clusterAdminPassword": {
+          "description": "MongoDB clusterAdmin password",
+          "type": "string",
+          "default": "clusteradminpassword"
+        },
+        "clusterMonitorUser": {
+          "description": "MongoDB clusterMonitor user name",
+          "type": "string",
+          "default": "clustermonitor"
+        },
+        "clusterMonitorPassword": {
+          "description": "MongoDB clusterMonitor password",
+          "type": "string",
+          "default": "clustermonitorpassword"
+        },
+        "key": {
+          "description": "The key to be used for intra-node communication, e.g. generated by 'openssl rand -base64 756'",
+          "type": "string",
+          "default": "VCeZ9zWjiNJQDZxXBZA4jfeI9YHUrWmRJDe7DKOG34b/mzER0hncruRlKLYT9HNUiU7ABxvNQ7jj1mSgmDpVt+XfKEpI3TTCJYjEAf/8G9Saeu8pdETCAd/l8xLZOAYbZd2yjhIWagiOjDz1i56GN+R51I11mSLUcGdhXVmSOCV6rrrqAtY+3+0KaWPFOnbkTHJdm3mPrts+oFT2VjGhg2yNzcfCI9FwEVPX3PWW5dbryEAHIBUapXSsMJcBFlD730DWk/MbEZSV/B/hkaFEDXgvEJszTLT6U9a2Dg4v7+eN97mK/87iKMDPIXZ5wzjbH9XNYHFVY5ensP6pmdscU9osY2MdCYhFotJHUJfGmMNbj2d1tvcc4GuFMqGcFrTyrr2E9QKm4QOtRnxLAeE2AIX0XbXxyEEbDGkKpJRLiiJRIREHh4VP6DZDzhntgcuOwWBhCLiRGDID0m1UyDe1qMXk+yy1mSRWAdfQtjXTVdS1o+AIBCxM0L0rM3rSto1PeA3CJcN1CjTfWq0t4t9mUOy4QO/juXaZCsvRDl8FKUsjnQfnocsRlWrqCGI7ONsbJdaEuiKxtu7H1WR0A+qdtBK/tZmTgbN9q0CCaP7Y1a48R5UHJAPS3HobOrqxNXEgYn+rhADUt0/ahRMuOBMTx/zm+VG8BFl8AmjOPQItvNOc9A08bKPg7lEqlzzcsTMa9QEJcW1sN9Io2F+ibKsiK9CdlPhPEUh2zMtex5e9LbT/102cmqJezq/16/xy9GYC7GwgYkrMoEbEfKdtUvVyQRijy4UE7bl9bdEgrIEY4Rs+TlR1zIRc8nl1RgL1pQp0V/gOuU/a5G5UMfIu9uZe5kgsS7T/8TQ3bzA9JpLVyCJx9rp8jvmcWO4RfOa6rKHT6pAjo1tf+VJ/mdJAwebxcpD/OPhEmfuTH5WqS3Vb/vWRbkFfC6nn+P2oB95+bF2yvA5PnkwswMTiI9Q/zSW8b4QrKyBXbd003c4FxplAGoQr2ukY"
+        },
+        "storageEngine": {
+          "title": "storage.engine",
+          "description": "Percona MongoDB storage engine (options: wiredTiger, rocksdb, mmapv1 or inMemory)",
+          "type": "string",
+          "enum": [
+            "wiredTiger",
+            "rocksdb",
+            "mmapv1",
+            "inMemory"
+          ],
+          "default": "wiredTiger"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count",
+        "replicaSetName",
+        "port",
+        "nodePlacement",
+        "backupUser",
+        "backupPassword",
+        "userAdminUser",
+        "userAdminPassword",
+        "clusterAdminUser",
+        "clusterAdminPassword",
+        "clusterMonitorUser",
+        "clusterMonitorPassword",
+        "key",
+        "storageEngine"
+      ]
+    },
+    "mongodb-advanced": {
+      "description": "MongoDB server advanced server configuration properties. Adjust with caution!",
+      "type": "object",
+      "properties": {
+        "openFileLimit": {
+          "title": "Open Files Limit (ulimit)",
+          "description": "Maximum number of open files inside the container ('NOFILE' ulimit setting)",
+          "type": "number",
+          "default": 64000,
+          "minimum": 1024
+        },
+        "processLimit": {
+          "title": "Max Processes Limit (ulimit)",
+          "description": "Maximum number of processes running inside the container ('NPROC' ulimit setting)",
+          "type": "number",
+          "default": 64000,
+          "minimum": 1024
+        },
+        "securityRedactClientLogData": {
+          "title": "security.redactClientLogData",
+          "description": "Prevents writing of potentially sensitive data stored on the database to the diagnostic log",
+          "type": "boolean",
+          "default": false
+        },
+        "storageIndexBuildRetry": {
+          "title": "storage.indexBuildRetry",
+          "description": "Specifies whether mongod rebuilds incomplete indexes on the next start up",
+          "type": "boolean",
+          "default": true
+        },
+        "storageJournalEnabled": {
+          "title": "storage.journal.enabled",
+          "description": "Enable or disable the durability journal to ensure data files remain valid and recoverable",
+          "type": "boolean",
+          "default": true
+        },
+        "storageJournalCommitIntervalMs": {
+          "title": "storage.journal.commitIntervalMs",
+          "description": "The maximum amount of time in milliseconds that the mongod process allows between journal operations",
+          "type": "integer",
+          "default": 100,
+          "minimum": 1
+        },
+        "storageDirectoryPerDB": {
+          "title": "storage.directoryPerDB",
+          "description": "When true, MongoDB uses a separate directory to store data for each database",
+          "type": "boolean",
+          "default": false
+        },
+        "storageSyncPeriodSecs": {
+          "title": "storage.syncPeriodSecs",
+          "description": "The amount of time that can pass before MongoDB flushes data to the data files via an fsync operation",
+          "type": "integer",
+          "default": 60
+        },
+        "storageMMAPv1PreallocDataFiles": {
+          "title": "storage.mmapv1.preallocDataFiles",
+          "description": "Enables or disables the preallocation of data files. By default, MongoDB does not preallocate data files",
+          "type": "boolean",
+          "default": true
+        },
+        "storageMMAPv1NsSize": {
+          "title": "storage.mmapv1.nsSize",
+          "description": "The default size for namespace files, which are files that end in .ns. Each collection and index counts as a namespace",
+          "type": "integer",
+          "default": 16
+        },
+        "storageMMAPv1QuotaEnforced": {
+          "title": "storage.mmapv1.quota.enforced",
+          "description": "Enable or disable the enforcement of a maximum limit for the number data files each database can have",
+          "type": "boolean",
+          "default": false
+        },
+        "storageMMAPv1QuotaMaxFilesPerDB": {
+          "title": "storage.mmapv1.quota.maxFilesPerDB",
+          "description": "The limit on the number of data files per database",
+          "type": "integer",
+          "default": 8
+        },
+        "storageMMAPv1SmallFiles": {
+          "title": "storage.mmapv1.smallFiles",
+          "description": "When true, MongoDB uses a smaller default file size",
+          "type": "boolean",
+          "default": false
+        },
+        "storageRocksDBCompression": {
+          "title": "storage.rocksdb.compression",
+          "description": "Specifies the block compression algorithm for data collection. Possible values: none, snappy, zlib, lz4, lz4hc",
+          "type": "string",
+          "enum": [
+            "snappy",
+            "none",
+            "zlib",
+            "lz4",
+            "lz4hc"
+          ],
+          "default": "snappy"
+        },
+        "storageRocksDBMaxWriteMBPerSec": {
+          "title": "storage.rocksdb.maxWriteMBPerSec",
+          "description": "Specifies the maximum speed at which RocksDB writes to storage in megabytes per second. Decrease this value to reduce read latency spikes during compactions. However, reducing it too much might slow down writes",
+          "type": "integer",
+          "default": 1024
+        },
+        "storageRocksDBCrashSafeCounters": {
+          "title": "storage.rocksdb.crashSafeCounters",
+          "description": "Specifies whether to correct counters after a crash. Enabling this can affect write performance",
+          "type": "boolean",
+          "default": false
+        },
+        "storageWiredTigerEngineConfigJournalCompressor": {
+          "title": "storage.wiredTiger.engineConfig.journalCompressor",
+          "description": "The type of compression to use to compress WiredTiger journal data. Available compressors are: none, snappy, zlib",
+          "type": "string",
+          "enum": [
+            "snappy",
+            "none",
+            "zlib"
+          ],
+          "default": "snappy"
+        },
+        "storageWiredTigerEngineConfigDirectoryForIndexes": {
+          "title": "storage.wiredTiger.engineConfig.directoryForIndexes",
+          "description": "When true, mongod stores indexes and collections in separate subdirectories under the data (i.e. storage.dbPath) directory",
+          "type": "boolean",
+          "default": false
+        },
+        "storageWiredTigerCollectionConfigBlockCompressor": {
+          "title": "storage.wiredTiger.collectionConfig.blockCompressor",
+          "description": "The default type of compression to use to compress collection data. You can override this on a per-collection basis when creating collections. Available compressors are: none, snappy, zlib",
+          "type": "string",
+          "enum": [
+            "snappy",
+            "none",
+            "zlib"
+          ],
+          "default": "snappy"
+        },
+        "storageWiredTigerIndexConfigPrefixCompression": {
+          "title": "storage.wiredTiger.indexConfig.prefixCompression",
+          "description": "Specify true to enable prefix compression for index data, or false to disable prefix compression for index data",
+          "type": "boolean",
+          "default": true
+        },
+        "setParameterFailIndexKeyTooLong": {
+          "title": "setParameter: failIndexKeyTooLong",
+          "description": "Enable failing of updates and inserts that have indexed values longer than the Index Key Length Limit",
+          "type": "boolean",
+          "default": true
+        },
+        "setParameterMaxIndexBuildMemoryUsageMB": {
+          "title": "setParameter: maxIndexBuildMemoryUsageMB",
+          "description": "Limits the amount of memory that simultaneous foreground index builds on one collection may consume for the duration of the builds",
+          "type": "integer",
+          "default": 500
+        },
+        "setParameterLogUserIds": {
+          "title": "setParameter: logUserIds",
+          "description": "Enable logging of user IDs. 1 = true, 0 = false",
+          "enum": [
+            0,
+            1
+          ],
+          "type": "integer",
+          "default": 0
+        },
+        "setParameterTTLMonitorEnabled": {
+          "title": "setParameter: ttlMonitorEnabled",
+          "description": "Enable background thread that is responsible for deleting documents from collections with TTL indexes",
+          "type": "boolean",
+          "default": true
+        },
+        "setParameterTTLMonitorSleepSecs": {
+          "title": "setParameter: ttlMonitorSleepSecs",
+          "description": "Defines the number of seconds to wait between checking TTL Indexes for old documents and removing them",
+          "type": "integer",
+          "default": 60,
+          "minimum": 1
+        },
+        "setParameterRocksDBConcurrentReadTransactions": {
+          "title": "setParameter: rocksdbConcurrentReadTransactions",
+          "description": "Maximum number of concurrently running read transactions in the RocksDB engine",
+          "type": "integer",
+          "default": 128,
+          "minimum": 1
+        },
+        "setParameterRocksDBConcurrentWriteTransactions": {
+          "title": "setParameter: rocksdbConcurrentWriteTransactions",
+          "description": "Maximum number of concurrently running write transactions in the RocksDB engine",
+          "type": "integer",
+          "default": 128,
+          "minimum": 1
+        },
+        "setParameterWiredTigerConcurrentReadTransactions": {
+          "title": "setParameter: wiredTigerConcurrentReadTransactions",
+          "description": "Maximum number of concurrently running read transactions in the WiredTiger engine",
+          "type": "integer",
+          "default": 128,
+          "minimum": 1
+        },
+        "setParameterWiredTigerConcurrentWriteTransactions": {
+          "title": "setParameter: wiredTigerConcurrentWriteTransactions",
+          "description": "Maximum number of concurrently running write transactions in the WiredTiger engine",
+          "type": "integer",
+          "default": 128,
+          "minimum": 1
+        },
+        "netMaxIncomingConnections": {
+          "title": "net.maxIncomingConnections",
+          "description": "Specify the maximum number of incoming connections",
+          "type": "number",
+          "default": 51200,
+          "minimum": 1
+        },
+        "operationProfilingMode": {
+          "title": "operationProfiling.mode",
+          "description": "Percona MongoDB operation profiling mode (options: slowOp, all or off)",
+          "type": "string",
+          "enum": [
+            "slowOp",
+            "off",
+            "all"
+          ],
+          "default": "slowOp"
+        },
+        "operationProfilingSlowOpThresholdMs": {
+          "title": "operationProfiling.slowOpThresholdMs",
+          "description": "Percona MongoDB operation profiling slowOp mode threshold in milliseconds",
+          "type": "integer",
+          "default": 100,
+          "minimum": 1
+        },
+        "operationProfilingRateLimit": {
+          "title": "operationProfiling.rateLimit",
+          "description": "Percona MongoDB operation profiling rate limiting value",
+          "type": "integer",
+          "default": 1
+        },
+        "replicationSecondaryIndexPrefetch": {
+          "title": "replication.secondaryIndexPrefetch",
+          "description": "The indexes that secondary members of a replica set load into memory before applying operations from the oplog",
+          "type": "string",
+          "enum": [
+            "none",
+            "_id_only",
+            "all"
+          ],
+          "default": "all"
+        },
+        "replicationEnableMajorityReadConcern": {
+          "title": "replication.enableMajorityReadConcern",
+          "description": "Enables read concern level of 'majority'",
+          "type": "boolean",
+          "default": false
+        },
+        "systemLogVerbosity": {
+          "title": "systemLog.verbosity",
+          "description": "The default log message verbosity level for components. The verbosity level determines the amount of Informational and Debug messages MongoDB outputs. The verbosity level can range from 0 to 5",
+          "type": "integer",
+          "enum": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "default": 0
+        },
+        "systemTraceAllExceptions": {
+          "title": "systemLog.traceAllExceptions",
+          "description": "Print verbose information for debugging. Use for additional logging for support-related troubleshooting",
+          "type": "boolean",
+          "default": false
+        },
+        "systemLogTimestampFormat": {
+          "title": "systemLog.timestampFormat",
+          "description": "The time format for timestamps in log messages. Specify one of the following values: ctime, iso8601-utc, iso8601-local",
+          "type": "string",
+          "enum": [
+            "iso8601-local",
+            "ctime",
+            "iso8601-utc"
+          ],
+          "default": "iso8601-local"
+        }
+      },
+      "required": [
+        "openFileLimit",
+        "processLimit",
+        "storageIndexBuildRetry",
+        "storageJournalEnabled",
+        "storageJournalCommitIntervalMs",
+        "storageDirectoryPerDB",
+        "storageSyncPeriodSecs",
+        "storageMMAPv1PreallocDataFiles",
+        "storageMMAPv1NsSize",
+        "storageMMAPv1QuotaEnforced",
+        "storageMMAPv1QuotaMaxFilesPerDB",
+        "storageMMAPv1SmallFiles",
+        "storageRocksDBCompression",
+        "storageRocksDBMaxWriteMBPerSec",
+        "storageRocksDBCrashSafeCounters",
+        "storageWiredTigerEngineConfigJournalCompressor",
+        "storageWiredTigerEngineConfigDirectoryForIndexes",
+        "storageWiredTigerCollectionConfigBlockCompressor",
+        "storageWiredTigerIndexConfigPrefixCompression",
+        "setParameterFailIndexKeyTooLong",
+        "setParameterMaxIndexBuildMemoryUsageMB",
+        "setParameterLogUserIds",
+        "setParameterTTLMonitorEnabled",
+        "setParameterTTLMonitorSleepSecs",
+        "setParameterRocksDBConcurrentReadTransactions",
+        "setParameterRocksDBConcurrentWriteTransactions",
+        "setParameterWiredTigerConcurrentReadTransactions",
+        "setParameterWiredTigerConcurrentWriteTransactions",
+        "netMaxIncomingConnections",
+        "operationProfilingMode",
+        "operationProfilingSlowOpThresholdMs",
+        "operationProfilingRateLimit",
+        "replicationSecondaryIndexPrefetch",
+        "replicationEnableMajorityReadConcern",
+        "systemLogVerbosity",
+        "systemTraceAllExceptions",
+        "systemLogTimestampFormat"
+      ]
+    },
+    "mongodb-auditlog": {
+      "description": "Percona Server for MongoDB AuditLog configuration properties. The audit log is written to the file 'auditLog.bson' in the MongoDB data path",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable PSMDB Audit Log",
+          "description": "Enables the Percona Server for MongoDB audit log feature",
+          "type": "boolean",
+          "default": false
+        },
+        "filter": {
+          "title": "auditLog.filter",
+          "description": "The filter document (in json style) to be used for filtering the Percona Server for MongoDB audit log",
+          "type": "string",
+          "default": "{}"
+        },
+        "auditAuthorizationSuccess": {
+          "title": "setParameter: auditAuthorizationSuccess",
+          "description": "Enables the logging of all read and write operations",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "enabled",
+        "filter",
+        "auditAuthorizationSuccess"
+      ]
+    },
+    "init": {
+      "description": "MongoDB init node configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "MongoDB init node cpu requirements",
+          "type": "number",
+          "default": 0.2
+        },
+        "mem": {
+          "description": "MongoDB init node mem requirements. Must be 64 or greater",
+          "type": "integer",
+          "default": 64,
+          "minimum": 64
+        },
+        "initiateDelay": {
+          "description": "The delay before starting the ReplicaSet initialization, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "15s"
+        },
+        "maxConnectTries": {
+          "description": "The number of times to try to connect to a database host",
+          "type": "integer",
+          "default": 30,
+          "minimum": 1
+        },
+        "maxInitReplsetTries": {
+          "description": "The number of times to try to initiate the replica set",
+          "type": "integer",
+          "default": 60,
+          "minimum": 1
+        },
+        "maxAddUsersTries": {
+          "description": "The number of times to try to add database users",
+          "type": "integer",
+          "default": 60,
+          "minimum": 1
+        },
+        "retrySleep": {
+          "description": "The duration to wait between retries",
+          "type": "string",
+          "default": "3s"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "watchdog": {
+      "description": "MongoDB watchdog node configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "MongoDB watchdog node cpu requirements",
+          "type": "number",
+          "default": 0.2
+        },
+        "mem": {
+          "description": "MongoDB watchdog node mem requirements. Must be 64 or greater",
+          "type": "integer",
+          "default": 64,
+          "minimum": 64
+        },
+        "delayWatcherStart": {
+          "description": "Amount of time to delay starting replica set watchers, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "20s"
+        },
+        "apiPoll": {
+          "description": "DCOS API poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "10s"
+        },
+        "apiTimeout": {
+          "description": "Pod API timeout than apiPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "5s"
+        },
+        "replsetPoll": {
+          "description": "MongoDB replica set state poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "5s"
+        },
+        "replsetTimeout": {
+          "description": "MongoDB replica set timeout, should be less than replsetPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "3s"
+        },
+        "replsetConfUpdatePoll": {
+          "description": "MongoDB replica set config update frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "10s"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "backup": {
+      "description": "Percona-Lab/mongodb_consistent_backup Backup configuration properties. Only mongodump-based backup and AWS S3 (for backup storage) is supported currently",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable backups",
+          "description": "Enable backups",
+          "type": "boolean",
+          "default": false
+        },
+        "hiddenSecondaryEnabled": {
+          "title": "Add dedicated MongoDB backup node",
+          "description": "Add a hidden-secondary MongoDB node dedicated to backup operations. This node cannot become primary and is invible to MongoDB drivers. The node will inherit any config options passed to the other mongod nodes",
+          "type": "boolean",
+          "default": true
+        },
+        "hiddenSecondaryCpus": {
+          "title": "Dedicated MongoDB backup node cpus",
+          "description": "MongoDB backup hidden-secondary node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "hiddenSecondaryMem": {
+          "title": "Dedicated MongoDB backup node mem",
+          "description": "MongoDB backup hidden-secondary node mem requirements, in megabytes",
+          "type": "integer",
+          "default": 1024
+        },
+        "backupCpus": {
+          "title": "Backup node cpus",
+          "description": "mongodb_consistent_backup node cpu requirements",
+          "type": "number",
+          "default": 2.0
+        },
+        "backupMem": {
+          "title": "Backup node mem",
+          "description": "mongodb_consistent_backup node mem requirements, in megabytes",
+          "type": "integer",
+          "default": 1024
+        },
+        "archiveMethod": {
+          "title": "archive.method",
+          "description": "mongodb_consistent_backup archive method (none or tar)",
+          "enum": [
+            "none",
+            "tar"
+          ],
+          "type": "string",
+          "default": "none"
+        },
+        "uploadThreads": {
+          "title": "upload.threads",
+          "description": "mongodb_consistent_backup upload thread count",
+          "type": "integer",
+          "default": 4
+        },
+        "uploadRetries": {
+          "title": "upload.retries",
+          "description": "mongodb_consistent_backup upload retry count",
+          "type": "integer",
+          "default": 5
+        },
+        "uploadS3Region": {
+          "title": "upload.s3.region",
+          "description": "mongodb_consistent_backup upload s3 region for upload",
+          "type": "string",
+          "default": "us-east-1"
+        },
+        "uploadS3AccessKey": {
+          "title": "upload.s3.access_key",
+          "description": "mongodb_consistent_backup upload s3 access key",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3SecretKey": {
+          "title": "upload.s3.secret_key",
+          "description": "mongodb_consistent_backup upload s3 secret key",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3BucketName": {
+          "title": "upload.s3.bucket_name",
+          "description": "mongodb_consistent_backup upload s3 bucket name",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3BucketPrefix": {
+          "title": "upload.s3.bucket_prefix",
+          "description": "mongodb_consistent_backup upload s3 bucket key prefix",
+          "type": "string",
+          "default": "/"
+        },
+        "uploadS3ObjectACL": {
+          "title": "upload.s3.object_acl",
+          "description": "mongodb_consistent_backup upload s3 object acl",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3UploadChunkSizeMb": {
+          "title": "upload.s3.chunk_size_mb",
+          "description": "mongodb_consistent_backup upload s3 chunk size in megabytes",
+          "type": "integer",
+          "default": 50,
+          "minimum": 1
+        },
+        "verbose": {
+          "description": "Enable mongodb_consistent_backup verbose logging",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "enabled",
+        "hiddenSecondaryEnabled",
+        "hiddenSecondaryCpus",
+        "hiddenSecondaryMem",
+        "backupCpus",
+        "backupMem",
+        "archiveMethod",
+        "uploadThreads",
+        "uploadRetries",
+        "uploadS3Region",
+        "uploadS3BucketPrefix",
+        "uploadS3UploadChunkSizeMb",
+        "verbose"
+      ]
+    },
+    "percona-pmm": {
+      "description": "Percona PMM monitoring configuration properties. This section assumes you have setup a PMM server beforehand, ie: it does NOT create a PMM server!",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable Percona PMM monitoring",
+          "description": "Enable Percona Monitoring & Management (PMM) monitoring of MongoDB and Linux",
+          "type": "boolean",
+          "default": false
+        },
+        "enableQueryAnalytics": {
+          "title": "Enable PMM Query Analytics (QAN) for MongoDB",
+          "description": "Enable Percona PMM Query Analytics (QAN) for MongoDB. This feature uses query profiles to analyse MongoDB queries and commands",
+          "type": "boolean",
+          "default": true
+        },
+        "clientVersion": {
+          "title": "Percona PMM client version",
+          "description": "Percona PMM client version, currently only the versions displayed are supported!",
+          "type": "string",
+          "enum": [
+            "1.9.1"
+          ],
+          "default": "1.9.1"
+        },
+        "serverAddress": {
+          "title": "Percona PMM server address",
+          "description": "Percona PMM server address. Include a port number after a colon for non-standard ports, ie: 'pmm.my-domain.com:8080'",
+          "type": "string",
+          "default": "pmm-server.marathon.l4lb.thisdcos.directory:80"
+        },
+        "serverUseSSL": {
+          "title": "Use SSL connections",
+          "description": "Use SSL for communication with the PMM server",
+          "type": "boolean",
+          "default": false
+        },
+        "serverUseInsecureSSL": {
+          "title": "Use Insecure SSL connections",
+          "description": "Use SSL without validation for communication with the PMM server",
+          "type": "boolean",
+          "default": false
+        },
+        "serverUser": {
+          "title": "PMM Server username",
+          "description": "Username to be used for connections to the PMM Server. Automatically enables authentication",
+          "type": "string",
+          "default": ""
+        },
+        "serverPassword": {
+          "title": "PMM Server password",
+          "description": "Password to be used for connections to the PMM Server. A PMM Server username is required",
+          "type": "string",
+          "default": ""
+        },
+        "linuxMetricsExporterPort": {
+          "title": "PMM Client Linux metrics port",
+          "description": "Port to run the Linux operating system metrics exporter on, default of '0' will use a random, available port (recommended)",
+          "type": "integer",
+          "default": 0
+        },
+        "mongodbMetricsExporterPort": {
+          "title": "PMM Client MongoDB metrics port",
+          "description": "Port to run the MongoDB database metrics exporter on, default of '0' will use a random, available port (recommended)",
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "required": [
+        "enabled",
+        "enableQueryAnalytics",
+        "clientVersion",
+        "serverAddress",
+        "serverUseSSL",
+        "serverUseInsecureSSL",
+        "linuxMetricsExporterPort",
+        "mongodbMetricsExporterPort"
+      ]
+    },
+    "dcos-metrics": {
+      "description": "DC/OS Metrics configuration properties",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable DC/OS Metrics",
+          "description": "Enable the sending of MongoDB metrics to DC/OS Metrics",
+          "type": "boolean",
+          "default": false
+        },
+        "intervalSecs": {
+          "title": "Metrics Collect Interval",
+          "description": "The frequency to collect MongoDB metrics, in seconds",
+          "type": "integer",
+          "default": 10,
+          "minimum": 1
+        }
+      },
+      "required": [
+        "enabled",
+        "intervalSecs"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx-percona-mongo/0/marathon.json.mustache
+++ b/repo/packages/P/portworx-percona-mongo/0/marathon.json.mustache
@@ -1,0 +1,225 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./mongo-scheduler/bin/dcos-mongo ./mongo-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
+  "env": {
+    "PACKAGE_NAME": "portworx-percona-mongo",
+    "PACKAGE_VERSION": "1.2.2-3.4.14",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1529088409911",
+    "PACKAGE_BUILD_TIME_STR": "Fri Jun 15 2018 18:46:49 +0000",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "MONGODB_TOOLS_URI": "{{resource.assets.uris.mongodb-tools-zip}}",
+    "PSMDB_DOCKER_IMAGE": "{{resource.assets.container.docker.percona-server-mongodb}}",
+    "MCB_DOCKER_IMAGE": "{{resource.assets.container.docker.mongodb-consistent-backup}}",
+    "WATCHDOG_DOCKER_IMAGE": "{{resource.assets.container.docker.watchdog}}",
+
+    "MONGODB_VERSION": "3.4.14",
+
+    "MONGODB_PORT": "{{mongodb.port}}",
+    "MONGODB_COUNT": "{{mongodb.count}}",
+    "MONGODB_CPUS": "{{mongodb.cpus}}",
+    "MONGODB_MEM": "{{mongodb.mem}}",
+    "MONGODB_DISK_SIZE": "{{mongodb.disk}}",
+    "MONGODB_DOCKER_VOLUME_NAME": "{{{mongodb.portworx_volume_name}}}",
+    "MONGODB_DOCKER_DRIVER_OPTIONS": "{{{mongodb.portworx_volume_options}}}",
+    "MONGODB_REPLSET": "{{mongodb.replicaSetName}}",
+    "MONGODB_USER_ADMIN_USER": "{{mongodb.userAdminUser}}",
+    "MONGODB_USER_ADMIN_PASSWORD": "{{mongodb.userAdminPassword}}",
+    "MONGODB_CLUSTER_ADMIN_USER": "{{mongodb.clusterAdminUser}}",
+    "MONGODB_CLUSTER_ADMIN_PASSWORD": "{{mongodb.clusterAdminPassword}}",
+    "MONGODB_BACKUP_USER": "{{mongodb.backupUser}}",
+    "MONGODB_BACKUP_PASSWORD": "{{mongodb.backupPassword}}",
+    "MONGODB_CLUSTER_MONITOR_USER": "{{mongodb.clusterMonitorUser}}",
+    "MONGODB_CLUSTER_MONITOR_PASSWORD": "{{mongodb.clusterMonitorPassword}}",
+    "MONGODB_KEY": "{{mongodb.key}}",
+    {{#mongodb.nodePlacement}}
+        "MONGODB_NODE_PLACEMENT": "{{{mongodb.nodePlacement}}}",
+    {{/mongodb.nodePlacement}}
+
+    "MONGODB_STORAGE_ENGINE": "{{mongodb.storageEngine}}",
+
+    "MONGODB_NOFILE_LIMIT": "{{mongodb-advanced.openFileLimit}}",
+    "MONGODB_NPROC_LIMIT": "{{mongodb-advanced.processLimit}}",
+
+    "MONGODB_SECURITY_REDACT_CLIENT_LOG_DATA": "{{mongodb-advanced.securityRedactClientLogData}}",
+
+    "MONGODB_STORAGE_INDEX_BUILD_RETRY": "{{mongodb-advanced.storageIndexBuildRetry}}",
+    "MONGODB_STORAGE_JOURNAL_COMMIT_INTERVAL_MS": "{{mongodb-advanced.storageJournalCommitIntervalMs}}",
+    "MONGODB_STORAGE_DIRECTORY_PER_DB": "{{mongodb-advanced.storageDirectoryPerDB}}",
+    "MONGODB_STORAGE_SYNC_PERIOD_SECS": "{{mongodb-advanced.storageSyncPeriodSecs}}",
+
+    "MONGODB_STORAGE_MMAPV1_PREALLOC_DATA_FILES": "{{mongodb-advanced.storageMMAPv1PreallocDataFiles}}",
+    "MONGODB_STORAGE_MMAPV1_NS_SIZE": "{{mongodb-advanced.storageMMAPv1NsSize}}",
+    "MONGODB_STORAGE_MMAPV1_QUOTA_ENFORCED": "{{mongodb-advanced.storageMMAPv1QuotaEnforced}}",
+    "MONGODB_STORAGE_MMAPV1_MAX_FILES_PER_DB": "{{mongodb-advanced.storageMMAPv1QuotaMaxFilesPerDB}}",
+    "MONGODB_STORAGE_MMAPV1_SMALLFILES": "{{mongodb-advanced.storageMMAPv1SmallFiles}}",
+
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_JOURNAL_COMPRESSOR": "{{mongodb-advanced.storageWiredTigerEngineConfigJournalCompressor}}",
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_DIRECTORY_FOR_INDEXES": "{{mongodb-advanced.storageWiredTigerEngineConfigDirectoryForIndexes}}",
+    "MONGODB_STORAGE_WIREDTIGER_COLLECTION_CONFIG_BLOCK_COMPRESSOR": "{{mongodb-advanced.storageWiredTigerCollectionConfigBlockCompressor}}",
+    "MONGODB_STORAGE_WIREDTIGER_INDEX_CONFIG_PREFIX_COMPRESSION": "{{mongodb-advanced.storageWiredTigerIndexConfigPrefixCompression}}",
+
+    "MONGODB_STORAGE_ROCKSDB_COMPRESSION": "{{mongodb-advanced.storageRocksDBCompression}}",
+    "MONGODB_STORAGE_ROCKSDB_WRITE_MB_PER_SEC": "{{mongodb-advanced.storageRocksDBMaxWriteMBPerSec}}",
+    "MONGODB_STORAGE_ROCKSDB_CRASH_SAFE_COUNTERS": "{{mongodb-advanced.storageRocksDBCrashSafeCounters}}",
+
+    "MONGODB_SET_PARAMETER_AUDIT_AUTHORIZATION_SUCCESS": "{{mongodb-auditlog.auditAuthorizationSuccess}}",
+    "MONGODB_SET_PARAMETER_FAIL_INDEX_KEY_TOO_LONG": "{{mongodb-advanced.setParameterFailIndexKeyTooLong}}",
+    "MONGODB_SET_PARAMETER_MAX_INDEX_BUILD_MEMORY_USAGE_MB": "{{mongodb-advanced.setParameterMaxIndexBuildMemoryUsageMB}}",
+    "MONGODB_SET_PARAMETER_LOG_USER_IDS": "{{mongodb-advanced.setParameterLogUserIds}}",
+    "MONGODB_SET_PARAMETER_TTL_MONITOR_ENABLED": "{{mongodb-advanced.setParameterTTLMonitorEnabled}}",
+    "MONGODB_SET_PARAMETER_TTL_MONITOR_SLEEP_SECS": "{{mongodb-advanced.setParameterTTLMonitorSleepSecs}}",
+    "MONGODB_SET_PARAMETER_ROCKSDB_CONCURRENT_READ_TRANSACTIONS": "{{mongodb-advanced.setParameterRocksDBConcurrentReadTransactions}}",
+    "MONGODB_SET_PARAMETER_ROCKSDB_CONCURRENT_WRITE_TRANSACTIONS": "{{mongodb-advanced.setParameterRocksDBConcurrentWriteTransactions}}",
+    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_READ_TRANSACTIONS": "{{mongodb-advanced.setParameterWiredTigerConcurrentReadTransactions}}",
+    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_WRITE_TRANSACTIONS": "{{mongodb-advanced.setParameterWiredTigerConcurrentWriteTransactions}}",
+
+    "MONGODB_NET_MAX_INCOMING_CONNECTIONS": "{{mongodb-advanced.netMaxIncomingConnections}}",
+
+    "MONGODB_OPERATION_PROFILING_MODE": "{{mongodb-advanced.operationProfilingMode}}",
+    "MONGODB_OPERATION_PROFILING_SLOWOP_THRESHOLD_MS": "{{mongodb-advanced.operationProfilingSlowOpThresholdMs}}",
+    "MONGODB_OPERATION_PROFILING_RATE_LIMIT": "{{mongodb-advanced.operationProfilingRateLimit}}",
+
+    "MONGODB_REPLICATION_SECONDARY_INDEX_PREFETCH": "{{mongodb-advanced.replicationSecondaryIndexPrefetch}}",
+    "MONGODB_REPLICATION_ENABLE_MAJORITY_READ_CONCERN": "{{mongodb-advanced.replicationEnableMajorityReadConcern}}",
+
+    "MONGODB_AUDIT_LOG_ENABLED": "{{mongodb-auditlog.enabled}}",
+    "MONGODB_AUDIT_LOG_FILTER": "{{mongodb-auditlog.filter}}",
+
+    "MONGODB_SYSTEM_LOG_VERBOSITY": "{{mongodb-advanced.systemLogVerbosity}}",
+    "MONGODB_SYSTEM_LOG_TRACE_ALL_EXCEPTIONS": "{{mongodb-advanced.systemTraceAllExceptions}}",
+    "MONGODB_SYSTEM_LOG_TIMESTAMP_FORMAT": "{{mongodb-advanced.systemLogTimestampFormat}}",
+
+    {{#service.virtual_networks}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{node.virtual_network}}",
+    "CNI_PLUGIN_LABELS": "{{node.cni_plugin_labels}}",
+    {{/service.virtual_networks}}
+
+    "INIT_CPUS": "{{init.cpus}}",
+    "INIT_MEM": "{{init.mem}}",
+    "INIT_INITIATE_DELAY": "{{init.initiateDelay}}",
+    "INIT_MAX_CONNECT_TRIES": "{{init.maxConnectTries}}",
+    "INIT_MAX_INIT_REPLSET_TRIES": "{{init.maxInitReplsetTries}}",
+    "INIT_MAX_ADD_USERS_TRIES": "{{init.maxAddUsersTries}}",
+    "INIT_RETRY_SLEEP": "{{init.retrySleep}}",
+
+    "WATCHDOG_CPUS": "{{watchdog.cpus}}",
+    "WATCHDOG_MEM": "{{watchdog.mem}}",
+    "WATCHDOG_API_TIMEOUT": "{{watchdog.apiTimeout}}",
+    "WATCHDOG_API_POLL": "{{watchdog.apiPoll}}",
+    "WATCHDOG_REPLSET_TIMEOUT": "{{watchdog.replsetTimeout}}",
+    "WATCHDOG_REPLSET_POLL": "{{watchdog.replsetPoll}}",
+    "WATCHDOG_REPLSET_CONF_UPDATE_POLL": "{{watchdog.replsetConfUpdatePoll}}",
+    "WATCHDOG_DELAY_WATCHER_START": "{{watchdog.delayWatcherStart}}",
+
+    "BACKUP_ENABLED": "{{backup.enabled}}",
+    "BACKUP_VERSION": "1.3.0",
+    {{#backup.enabled}}
+    "BACKUP_HIDDEN_SECONDARY_ENABLED": "{{backup.hiddenSecondaryEnabled}}",
+    "BACKUP_HIDDEN_SECONDARY_CPUS": "{{backup.hiddenSecondaryCpus}}",
+    "BACKUP_HIDDEN_SECONDARY_MEM": "{{backup.hiddenSecondaryMem}}",
+    "BACKUP_CPUS": "{{backup.backupCpus}}",
+    "BACKUP_MEM": "{{backup.backupMem}}",
+    "BACKUP_VERBOSE": "{{backup.verbose}}",
+    "BACKUP_ARCHIVE_METHOD": "{{backup.archiveMethod}}",
+    "BACKUP_UPLOAD_THREADS": "{{backup.uploadThreads}}",
+    "BACKUP_UPLOAD_RETRIES": "{{backup.uploadRetries}}",
+    "BACKUP_UPLOAD_S3_REGION": "{{backup.uploadS3Region}}",
+    "BACKUP_UPLOAD_S3_ACCESS_KEY": "{{backup.uploadS3AccessKey}}",
+    "BACKUP_UPLOAD_S3_SECRET_KEY": "{{backup.uploadS3SecretKey}}",
+    "BACKUP_UPLOAD_S3_BUCKET_NAME": "{{backup.uploadS3BucketName}}",
+    "BACKUP_UPLOAD_S3_BUCKET_PREFIX": "{{backup.uploadS3BucketPrefix}}",
+    "BACKUP_UPLOAD_S3_OBJECT_ACL": "{{backup.uploadS3ObjectACL}}",
+    "BACKUP_UPLOAD_S3_CHUNK_SIZE_MB": "{{backup.uploadS3UploadChunkSizeMb}}",
+    {{/backup.enabled}}
+
+    "PMM_ENABLED": "{{percona-pmm.enabled}}",
+    {{#percona-pmm.enabled}}
+    "PMM_ENABLE_QUERY_ANALYTICS": "{{percona-pmm.enableQueryAnalytics}}",
+    "PMM_CLIENT_VERSION": "{{percona-pmm.clientVersion}}",
+    "PMM_SERVER_ADDRESS": "{{percona-pmm.serverAddress}}",
+    "PMM_SERVER_USE_SSL": "{{percona-pmm.serverUseSSL}}",
+    "PMM_SERVER_USE_INSECURE_SSL": "{{percona-pmm.serverUseInsecureSSL}}",
+    "PMM_SERVER_USER": "{{percona-pmm.serverUser}}",
+    "PMM_SERVER_PASSWORD": "{{percona-pmm.serverPassword}}",
+    "PMM_LINUX_METRICS_EXPORTER_PORT": "{{percona-pmm.linuxMetricsExporterPort}}",
+    "PMM_MONGODB_METRICS_EXPORTER_PORT": "{{percona-pmm.mongodbMetricsExporterPort}}",
+    {{/percona-pmm.enabled}}
+
+    "DCOS_METRICS_ENABLED": "{{dcos-metrics.enabled}}",
+    "DCOS_METRICS_INTERVAL_SECS": "{{dcos-metrics.intervalSecs}}",
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    {{#service.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.secret_name}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.mongodb-tools-zip}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-percona-mongo/0/package.json
+++ b/repo/packages/P/portworx-percona-mongo/0/package.json
@@ -1,0 +1,26 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "*"
+  ],
+  "downgradesTo": [
+    "*"
+  ],
+  "minDcosReleaseVersion": "1.10",
+  "name": "portworx-percona-mongo",
+  "version": "1.2.2-3.4.14",
+  "maintainer": "support@portworx.com",
+  "description": "Percona Server for MongoDB Replica Set on Mesosphere DC/OS backed by Portworx volumes",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "mongo",
+    "mongodb",
+    "percona",
+    "portworx",
+    "nosql"
+  ],
+  "postInstallNotes": "The DC/OS Mongo service is being installed. \n\n\tDocumentation: https://docs.mesosphere.com/service-docs/percona-mongo/\n\tIssues: support@portworx.com",
+  "postUninstallNotes": "DC/OS Mongo is being uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 10240 MB MEM | 1 1000 MB Disk\n\nPortworx should be installed on the Private Agents to be able to provision volumes."
+}

--- a/repo/packages/P/portworx-percona-mongo/0/resource.json
+++ b/repo/packages/P/portworx-percona-mongo/0/resource.json
@@ -1,0 +1,64 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "percona-server-mongodb": "percona/percona-server-mongodb:3.4.14",
+        "mongodb-consistent-backup": "perconalab/mongodb_consistent_backup:1.3.0",
+        "watchdog": "debian:jessie"
+      }
+    },
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
+      "bootstrap-zip": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.2.2/bootstrap.zip",
+      "scheduler-zip": "https://disrani-dcos.s3.amazonaws.com/portworx-percona-mongo/assets/1.2.2-3.4.14/mongo-scheduler.zip",
+      "executor-zip": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.2.2/executor.zip",
+      "mongodb-tools-zip": "https://disrani-dcos.s3.amazonaws.com/portworx-percona-mongo/assets/1.2.2-3.4.14/mongodb-tools.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://www.percona.com/sites/default/files/PSfMDB-48.png",
+    "icon-medium": "https://www.percona.com/sites/default/files/PSfMDB-96.png",
+    "icon-large": "https://www.percona.com/sites/default/files/PSfMDB-256.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "c86343d75f4b6ec3c9de379e388fd75bc2336afac18ed80c614d20574c2445ec"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://disrani-dcos.s3.amazonaws.com/portworx-percona-mongo/assets/1.2.2-3.4.14/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "9ec01372f750bc245147cddddeecf7345eb299a48f4385fd3cca7cffdf976225"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://disrani-dcos.s3.amazonaws.com/portworx-percona-mongo/assets/1.2.2-3.4.14/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "f75a61c1805842329b5b5ae717146a36d934f4e71329e7a35a8c36df2ab47629"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://disrani-dcos.s3.amazonaws.com/portworx-percona-mongo/assets/1.2.2-3.4.14/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/P/portworx/300/config.json
+++ b/repo/packages/P/portworx/300/config.json
@@ -1,0 +1,331 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "portworx"
+        },
+        "user": {
+          "description": "The user that runs the Portworx tasks.",
+          "type": "string",
+          "default": "root"
+        },
+        "principal": {
+          "title": "Custom principal (optional)",
+          "description": "The principal for the service instance, or empty to use the default.",
+          "type": "string",
+          "default": ""
+        },
+        "secret_name": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "node": {
+      "description": "Portworx Node properties",
+      "type": "object",
+      "properties": {
+        "portworx_cluster": {
+          "title": "Portworx Cluster Name",
+          "type": "string",
+          "default": "portworx-dcos"
+        },
+        "portworx_image": {
+          "title": "Portworx Image name",
+          "type": "string",
+          "default": "portworx/px-enterprise:1.3.1.4"
+        },
+        "portworx_options": {
+          "title": "Portworx Options",
+          "type": "string",
+          "default": "-a -x mesos"
+        },
+        "kvdb_servers": {
+          "title": "KVDB servers",
+          "description": "Comma seperated IP:PORT entries for the key value database (etcd or consul). If the etcd server is started using the pacakge this will be ignored",
+          "type": "string",
+          "default": ""
+        },
+        "container_parameters": {
+          "title": "Container parameters",
+          "type": "string",
+          "description": "Any additional paramters to pass in to the Portworx container. For example environment variables can be passed in using \"-e\"",
+          "default": ""
+        },
+        "count": {
+          "title": "Node count",
+          "description": "Number of Portworx nodes to run",
+          "type": "integer",
+          "default": 3
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        }
+      },
+      "required": [
+        "count",
+        "portworx_cluster",
+        "portworx_image",
+        "portworx_options"
+      ]
+    },
+    "secrets": {
+      "description": "Use DC/OS Secrets for features like volume encryption, cloudsnap authentication, etc. This should be enabled only for DC/OS Enterprise edition. \nNote: DC/OS Secrets will only be supported from Portworx version 1.4",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable DC/OS secrets",
+          "description": "If enabled, provide valid credentials below, so that Portworx can access the secrets as needed",
+          "type": "boolean",
+          "default": false
+        },
+        "base_path": {
+          "title": "Secrets base path",
+          "description": "The secrets base path that is accessible to Portworx (DC/OS user provided to access secrets) for reading and writing secrets. If not provided, Portworx will look for secrets at the top level",
+          "type": "string",
+          "default": ""
+        },
+        "dcos_username_secret": {
+          "title": "DC/OS username secret",
+          "description": "Secret path containing the username of the DC/OS user who has permissions to access the secrets under the secrets base path. Eg. portworx/dcos_username",
+          "type": "string",
+          "default": "portworx/dcos_username"
+        },
+        "dcos_password_secret": {
+          "title": "DC/OS password secret",
+          "description": "Secret path containing the password of the DC/OS user who has permissions to access the secrets under the secrets base path. Eg. portworx/dcos_password",
+          "type": "string",
+          "default": "portworx/dcos_password"
+        }
+      },
+      "required": [
+        "dcos_username_secret",
+        "dcos_password_secret"
+      ]
+    },
+    "etcd": {
+      "description": "Start a 3 node etcd cluster. Required for Portworx if you don't have either etcd or consul already running. For production it is recommended to run an etcd cluster outside your DC/OS cluster.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Start etcd",
+          "description": "If disabled, please enter the external etcd server IP on the service tab.",
+          "type": "boolean",
+          "default": false
+        },
+        "proxy_enabled": {
+          "title": "Start the etcd proxy",
+          "description": "Enable if you had installed an older version of the framework which had the etcd proxy. Not required for newer installations.",
+          "type": "boolean",
+          "default": false
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        },
+        "image": {
+          "title": "Etcd Image name",
+          "type": "string",
+          "default": "mesosphere/etcd-mesos:latest"
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "CPU requirements",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk_type": {
+          "title": "Type of disk to use for persisting data",
+          "description": "ROOT or MOUNT",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "disk_size": {
+          "title": "Dize of disk (MB)",
+          "type": "integer",
+          "default": 5120
+        },
+        "node_advertise_port": {
+          "title": "Cluster Node advertise port",
+          "description": "Port on which the etcd cluster nodes will listen",
+          "type": "integer",
+          "default": 1026
+        },
+        "node_peer_port": {
+          "title": "Cluster Node peer port",
+          "description": "Port on which the etcd cluster nodes will communicate with each other",
+          "type": "integer",
+          "default": 1027
+        },
+        "proxy_advertise_port": {
+          "title": "Cluster Proxy advertise port",
+          "description": "Port on which the etcd proxy will listen",
+          "type": "integer",
+          "default": 2379
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk_type",
+        "disk_size",
+        "node_advertise_port",
+        "node_peer_port",
+        "proxy_advertise_port",
+        "image"
+      ]
+    },
+    "influxdb": {
+      "description": "InfluxDB properties. This service is required to store Portworx cluster statistics by the Lightouse service",
+      "type": "object",
+      "properties": {
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "CPU requirements",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk_type": {
+          "title": "Type of disk to use for persisting data",
+          "description": "ROOT or MOUNT",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "disk_size": {
+          "title": "Dize of disk (MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "image": {
+          "title": "Influxdb Image name",
+          "type": "string",
+          "default": "influxdb:latest"
+        },
+        "listen_port": {
+          "title": "The port on which influxdb listens for incoming requests",
+          "type": "integer",
+          "default": 8086
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk_type",
+        "disk_size",
+        "image",
+        "listen_port"
+      ]
+    },
+    "lighthouse": {
+      "description": "Lighthouse exposes the web UI for Portworx. Start this if you don't want to connect to the central Portworx Lighthouse. \nNote: Lighthouse will not work with Portworx version 1.4 and above. Please use the latest framework to install Lighthouse for Portworx 1.4 and above.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Start Lighthouse",
+          "description": "Start the Lighthouse service. If this is disabled the influxdb service will also be disabled.",
+          "type": "boolean",
+          "default": false
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "CPU requirements",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "image": {
+          "title": "Lighthouse Image name",
+          "type": "string",
+          "default": "portworx/px-lighthouse:1.1.8"
+        },
+        "webui_port": {
+          "title": "WebUI Port",
+          "description": "",
+          "type": "integer",
+          "default": 8085
+        },
+        "company_name": {
+          "title": "Company Name",
+          "description": "Company Name to use for creating Lighthouse account",
+          "type": "string",
+          "default": "Portworx"
+        },
+        "admin_email": {
+          "title": "Administrator Email/Login",
+          "description": "Email to use for the Lighthouse account. Default password is admin and can be changed after first login. Used for resetting password and sending alerts.",
+          "type": "string",
+          "default": "portworx@yourcompany.com"
+        },
+        "admin_password": {
+          "title": "Administrator Password",
+          "description": "Password to use for the Lighthouse account.",
+          "type": "string",
+          "default": "admin"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "webui_port",
+        "company_name",
+        "admin_email",
+        "image"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx/300/marathon.json.mustache
+++ b/repo/packages/P/portworx/300/marathon.json.mustache
@@ -1,0 +1,128 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "user":"{{service.user}}",
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./portworx-scheduler/bin/portworx ./portworx-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
+  "env": {
+    "PACKAGE_NAME": "portworx",
+    "PACKAGE_VERSION": "1.2.2-1.3.1.4",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1528149409019",
+    "PACKAGE_BUILD_TIME_STR": "Mon Jun 04 2018 21:56:49 +0000",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+
+    "SERVICE_USER": "{{service.user}}",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+    "PORTWORX_CLUSTER_NAME": "{{node.portworx_cluster}}",
+    "PORTWORX_IMAGE_NAME": "{{{node.portworx_image}}}",
+    "PORTWORX_OPTIONS": "{{{node.portworx_options}}}",
+    "ETCD_ENABLED": "{{etcd.enabled}}",
+    {{#etcd.enabled}}
+    "ETCD_PROXY_ENABLED": "{{etcd.proxy_enabled}}",
+    {{/etcd.enabled}}
+    {{^etcd.enabled}}
+    "PORTWORX_KVDB_SERVERS": "{{node.kvdb_servers}}",
+    {{/etcd.enabled}}
+    {{#node.container_parameters}}
+    "NODE_CONTAINER_PARAMETERS": "{{{node.container_parameters}}}",
+    {{/node.container_parameters}}
+
+    "SECRETS_ENABLED": "{{secrets.enabled}}",
+    "SECRETS_DCOS_USERNAME": "{{{secrets.dcos_username_secret}}}",
+    "SECRETS_DCOS_PASSWORD": "{{{secrets.dcos_password_secret}}}",
+    {{#secrets.base_path}}
+    "SECRETS_BASE_PATH": "{{{secrets.base_path}}}",
+    {{/secrets.base_path}}
+
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    {{#service.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.secret_name}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+
+    "ETCD_PLACEMENT": "{{etcd.placement_constraint}}",
+    "ETCD_CPUS": "{{etcd.cpus}}",
+    "ETCD_MEM": "{{etcd.mem}}",
+    "ETCD_DISK_TYPE": "{{etcd.disk_type}}",
+    "ETCD_DISK_SIZE": "{{etcd.disk_size}}",
+    "ETCD_IMAGE": "{{etcd.image}}",
+    "ETCD_NODE_ADVERTISE_PORT": "{{etcd.node_advertise_port}}",
+    "ETCD_NODE_PEER_PORT": "{{etcd.node_peer_port}}",
+    "ETCD_PROXY_ADVERTISE_PORT": "{{etcd.proxy_advertise_port}}",
+
+    "INFLUXDB_PLACEMENT": "{{influxdb.placement_constraint}}",
+    "INFLUXDB_CPUS": "{{influxdb.cpus}}",
+    "INFLUXDB_MEM": "{{influxdb.mem}}",
+    "INFLUXDB_DISK_TYPE": "{{influxdb.disk_type}}",
+    "INFLUXDB_DISK_SIZE": "{{influxdb.disk_size}}",
+    "INFLUXDB_IMAGE": "{{influxdb.image}}",
+    "INFLUXDB_LISTEN_PORT": "{{influxdb.listen_port}}",
+
+    {{#lighthouse.enabled}}
+    "LIGHTHOUSE_ENABLED": "{{lighthouse.enabled}}",
+    {{/lighthouse.enabled}}
+    "LIGHTHOUSE_PLACEMENT": "{{lighthouse.placement_constraint}}",
+    "LIGHTHOUSE_CPUS": "{{lighthouse.cpus}}",
+    "LIGHTHOUSE_MEM": "{{lighthouse.mem}}",
+    "LIGHTHOUSE_IMAGE": "{{lighthouse.image}}",
+    "LIGHTHOUSE_WEBUI_PORT": "{{lighthouse.webui_port}}",
+    "LIGHTHOUSE_COMPANY_NAME": "{{lighthouse.company_name}}",
+    "LIGHTHOUSE_ADMIN_EMAIL": "{{lighthouse.admin_email}}",
+    "LIGHTHOUSE_ADMIN_PASSWORD": "{{lighthouse.admin_password}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx/300/package.json
+++ b/repo/packages/P/portworx/300/package.json
@@ -1,0 +1,36 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "1.2-1.3.1.4-7f19308",
+    "1.2.1-1.3.1.4"
+  ],
+  "downgradesTo": [],
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx",
+  "version": "1.2.2-1.3.1.4",
+  "scm": "https://github.com/portworx/px-dev",
+  "maintainer": "support@portworx.com",
+  "website": "https://www.portworx.com/",
+  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments. Portworx enables containerized applications to be persistent, portable and protected. For DCOS examples of Portworx, please see https://docs.portworx.com/scheduler/mesosphere-dcos/install.html",
+  "framework": true,
+  "selected": false,
+  "tags": [
+    "portworx",
+    "storage",
+    "data",
+    "cloud",
+    "volume",
+    "encryption",
+    "s3",
+    "database"
+  ],
+  "preInstallNotes": "NOTE: Portworx requires a key-value database such as etcd for configuring storage. A highly availbale clustered etcd with persistent storage is preferred. You can start a 3-node etcd cluster using this framework, but for production it is recommended to operate an etcd cluster outside of your DC/OS environment. Instructions to set up etcd can be found here: https://docs.portworx.com/maintain/etcd.html \n\nLighthouse is a management and GUI service that allows you to manage your Portworx cluster. Lighthouse is disabled by default and can be enabled from the Lighthouse tab during install. Default username/password for Lighthouse is portworx@yourcompany.com/admin \n\nCertified packages are verified by Mesosphere for interoperability with DC/OS. Community packages are unverified and unreviewed content from the community. This is a community package. Be aware that this particular community package installs and operates as a system process in such a way that the detailed status of that process is not directly visible through DC/OS. Monitoring and managing the PX application should only be performed directly through the PX management utility and not through the DC/OS dashboard. Please visit https://docs.portworx.com/scheduler/mesosphere-dcos/install.html for detailed instructions.",
+  "postInstallNotes": "To see how Portworx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures, please visit https://docs.portworx.com",
+  "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "Apache 2.0 License",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/repo/packages/P/portworx/300/resource.json
+++ b/repo/packages/P/portworx/300/resource.json
@@ -1,0 +1,64 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.2.2-1.3.1.4/portworx-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.2.2-1.3.1.4/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.2.2-1.3.1.4/bootstrap.zip"
+    },
+    "container": {
+      "docker": {
+        "portworx": "portworx/px-enterprise:1.3.1.4",
+        "lighthouse": "portworx/px-lighthouse:1.1.8",
+        "influxdb": "influxdb:latest",
+        "etcd": "mesosphere/etcd-mesos:latest"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-small.png",
+    "icon-medium": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-medium.png",
+    "icon-large": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "f7397fe151e0087d948b694285f2680e9c05735fadca44970b43db05b96d96fd"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.2.2-1.3.1.4/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "d6a81117bb65000162d74fcf1afc3e85615dddf2295d5861efcbe7df257445fa"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.2.2-1.3.1.4/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "7eef69eb09650bbfa5823cabfdb049196a3cce675b7646397afc588924d91b9a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.2.2-1.3.1.4/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx-percona-mongo 1.2.2-3.4.14 (automated commit)

Description:
Source URL: https://piyush-dcos.s3.amazonaws.com/try40/portworx-percona-mongo/20180615-114644-joN6B8uF9FNFiM8O/stub-universe-portworx-percona-mongo.json

Changes between revisions -1 => 0:
4 files added: [resource.json, package.json, marathon.json.mustache, config.json]
0 files removed: []
0 files changed:

```
```
