### PR TITLE
Release portworx-datastax-ops 1.2-2.3.0-6.1.2 (automated commit)



### DIFF
--- a/repo/packages/P/portworx-datastax-ops/0/config.json
+++ b/repo/packages/P/portworx-datastax-ops/0/config.json
@@ -1,0 +1,699 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of this DC/OS DSE OpsCenter instance",
+          "type": "string",
+          "default": "portworx-datastax-ops"
+        },
+        "service_secret_name": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account": {
+          "description": "The principal for the service instance.",
+          "type": "string",
+          "default": "datastax-ops-service-account"
+        },
+        "user": {
+          "description": "The user that runs the Cassandra nodes and owns the Mesos sandbox.",
+          "type": "string",
+          "default": "root"
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "default": "V1"
+        },
+        "virtual_networks": {
+          "description": "Enable DC/OS Virtual Networking",
+          "type": "boolean",
+          "default": false
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        },
+        "region": {
+          "description": "All OpsCenter nodes will run in this region.  When no region is specified the nodes are constrained to the local region.",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-region+string"
+          }
+        },
+        "security": {
+          "description": "OpsCenter security settings",
+          "type": "object",
+          "properties": {
+            "transport_encryption": {
+              "type": "object",
+              "description": "Transport encryption settings",
+              "properties": {
+                "enabled": {
+                  "description": "Enable transport encryption (TLS)",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "opscenter": {
+      "description": "OpsCenter pod configuration properties",
+      "type": "object",
+      "properties": {
+        "stomp_port": {
+          "title": "Stomp port",
+          "description": "Port used for DSE agents to reach OpsCenter. DSE default is 61620.",
+          "type": "integer",
+          "default": 31620
+        },
+        "placement_constraint": {
+          "title": "OpsCenter placement constraint",
+          "description": "Placement constraints for the OpsCenter node. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "[]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "virtual_network": {
+          "description": "Name of virtual network for Opscenter pod(s)",
+          "type": "string",
+          "default": "dcos"
+        },
+        "cni_plugin_labels": {
+          "description": "Labels to pass to CNI plugin. Comma-seperated key:value pairs. For example [k_0:v_0,k_1:v_1,...,k_n:v_n]",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "title": "OpsCenter CPU count",
+          "type": "number",
+          "default": 2
+        },
+        "mem": {
+          "title": "OpsCenter memory size (MB)",
+          "type": "integer",
+          "default": 4000
+        },
+        "heap": {
+          "title": "OpsCenter heap size (MB)",
+          "type": "integer",
+          "default": 2000
+        },
+        "jvm_opts": {
+          "title": "OpsCenter custom JVM/GC options",
+          "description": "For example '-XX:+CMSSomeSetting -XX:+SettingForGC'. See OpsCenter JVM Tuning documentation.",
+          "type": "string",
+          "default": ""
+        },
+        "disk": {
+          "title": "OpsCenter persistent volume size (MB)",
+          "type": "integer",
+          "default": 10240
+        },
+        "portworx_volume_name": {
+          "title": "Portworx volume name prefix for OpsCenter",
+          "type": "string",
+          "default": "DatastaxOpsCenterVolume"
+        },
+        "portworx_volume_options": {
+          "title": "Portworx volume options for OpsCenter. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "gui_port": {
+          "title": "OpsCenter GUI port",
+          "type": "integer",
+          "default": 8888
+        },
+        "spark_master_proxy_port": {
+          "title": "OpsCenter Spark Master proxy port",
+          "type": "integer",
+          "default": 17080
+        },
+        "cassandra_username": {
+          "title": "The username used to connect to Cassandra if authentication is enabled",
+          "type": "string",
+          "default": "cassandra"
+        },
+        "cassandra_password": {
+          "title": "The password used to connect to Cassandra if authentication is enabled.",
+          "type": "string",
+          "default": "cassandra"
+        },
+        "authentication": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-enabled",
+          "type": "object",
+          "description": "Authentication Configuration",
+          "properties": {
+            "enabled": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-enabled",
+              "type": "boolean",
+              "description": "Enable Authentication for accessing OpsCenter",
+              "default": false
+            },
+            "login_user": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-authentication_method",
+              "type": "string",
+              "description": "User name for OpsCenter's Internal or LDAP authentication",
+              "default": "admin"
+            },
+            "login_password": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-authentication_method",
+              "type": "string",
+              "description": "Password for OpsCenter's Internal or LDAP authentication",
+              "default": "admin"
+            },
+            "method": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-authentication_method",
+              "type": "string",
+              "description": "Authentication Method",
+              "default": ""
+            },
+            "timeout": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-timeout",
+              "type": "integer"
+            },
+            "password_hash_type": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-password_hash_type",
+              "type": "string"
+            },
+            "sqlite_connection_timeout": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-sqlite_connection_timeout",
+              "type": "integer"
+            },
+            "sqlite_max_active_connections": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__authentication-sqlite_max_active_connections",
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "ldap": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-server_host",
+          "type": "object",
+          "description": "LDAP Configuration",
+          "properties": {
+            "enabled": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-server_host",
+              "type": "boolean",
+              "description": "Enable LDAP",
+              "default": false
+            },
+            "server_host": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-server_host",
+              "type": "string",
+              "description": "Hostname of LDAP server",
+              "default": "localhost"
+            },
+            "server_port": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-server_port",
+              "type": "integer",
+              "description": "Port of LDAP server",
+              "default": 389
+            },
+            "search_dn": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-search_dn",
+              "type": "string"
+            },
+            "search_password": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-search_password",
+              "type": "string"
+            },
+            "user_search_base": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-user_search_base",
+              "type": "string"
+            },
+            "user_search_filter": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-user_search_filter",
+              "type": "string",
+              "default": "(uid={0})"
+            },
+            "user_memberof_attribute": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-user_memberof_attribute",
+              "type": "string"
+            },
+            "group_search_type": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-group_search_type",
+              "type": "string",
+              "enum": [
+                "directory_search",
+                "memberof_search"
+              ],
+              "default": "directory_search"
+            },
+            "group_search_base": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-group_search_base",
+              "type": "string"
+            },
+            "group_search_filter_with_dn": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-group_search_filter_with_dn",
+              "type": "string",
+              "default": "(member={0})"
+            },
+            "group_name_attribute": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-group_name_attribute",
+              "type": "string"
+            },
+            "admin_group_name": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-admin_group_name",
+              "type": "string"
+            },
+            "ldap_security": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ldap-ldap_security",
+              "type": "string",
+              "default": "None"
+            },
+            "connection_timeout": {
+              "id": "http://docs.datastax.com/en/latest-dse/datastax_enterprise/config/configDseYaml.html#configDseYaml__connection_timeout",
+              "type": "integer",
+              "default": 20
+            }
+          },
+          "additionalProperties": false
+        },
+        "webserver": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__webserver",
+          "type": "object",
+          "properties": {
+            "staticdir": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__webserver-staticdir",
+              "type": "string"
+            },
+            "sub_process_timeout": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__webserver-sub_process_timeout",
+              "type": "integer"
+            },
+            "ssl_port": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__webserver-ssl_port",
+              "type": "integer",
+              "default": 8443
+            }
+          },
+          "additionalProperties": false
+        },
+        "http_proxy_settings": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__http_proxy_settings",
+          "type": "object",
+          "properties": {
+            "proxy_url": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__http_proxy_settings-proxy_url",
+              "type": "string"
+            },
+            "proxy_username": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__http_proxy_settings-proxy_username",
+              "type": "string"
+            },
+            "proxy_password": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__http_proxy_settings-proxy_password",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "logging": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__logging",
+          "type": "object",
+          "properties": {
+            "resource_usage_interval": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__logging-resource_usage_interval",
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "definitions": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__definitions",
+          "type": "object",
+          "properties": {
+            "definitions_dir": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__definitions-definitions_dir",
+              "type": "string"
+            },
+            "auto_update": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__definitions-auto_update",
+              "type": "boolean",
+              "default": true
+            },
+            "download_host": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__definitions-download_host",
+              "type": "string"
+            },
+            "download_port": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__definitions-download_port",
+              "type": "integer"
+            },
+            "download_filename": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__definitions-download_filename",
+              "type": "string"
+            },
+            "hash_filename": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__definitions-hash_filename",
+              "type": "string"
+            },
+            "sleep": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__definitions-sleep",
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "agents": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents",
+          "type": "object",
+          "properties": {
+            "config_sleep": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-config_sleep",
+              "type": "integer"
+            },
+            "agent_install_poll_period": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-agent_install_poll_period",
+              "type": "integer"
+            },
+            "agent_install_mute_period": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-agent_install_mute_period",
+              "type": "integer"
+            },
+            "agent_install_timeout_period": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-agent_install_timeout_period",
+              "type": "integer"
+            },
+            "ssh_executable": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-ssh_executable",
+              "type": "string"
+            },
+            "scp_executable": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-scp_executable",
+              "type": "string"
+            },
+            "ssh_keygen_executable": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-ssh_keygen_executable",
+              "type": "string"
+            },
+            "ssh_keyscan_executable": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-ssh_keyscan_executable",
+              "type": "string"
+            },
+            "ssh_user_known_hosts_file": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-ssh_user_known_hosts_file",
+              "type": "string"
+            },
+            "ssh_sys_known_hosts_file": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-ssh_sys_known_hosts_file",
+              "type": "string"
+            },
+            "tmp_dir": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-tmp_dir",
+              "type": "string"
+            },
+            "not_seen_threshold": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-not_seen_threshold",
+              "type": "integer"
+            },
+            "call_agent_retry": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-call_agent_retry",
+              "type": "integer"
+            },
+            "agent_aggregation_flush": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-agent_aggregation_flush",
+              "type": "integer"
+            },
+            "http_poll_period": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-http_poll_period",
+              "type": "integer"
+            },
+            "path_to_install_script": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-path_to_install_script",
+              "type": "string"
+            },
+            "path_to_sudowrap": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__agents-path_to_sudowrap",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "stat_reporter": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__stat_reporter",
+          "type": "object",
+          "properties": {
+            "initial_sleep": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__stat_reporter-initial_sleep",
+              "type": "integer"
+            },
+            "interval": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__stat_reporter-interval",
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "repair_service": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service",
+          "type": "object",
+          "properties": {
+            "persist_directory": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-persist_directory",
+              "type": "string"
+            },
+            "persist_period": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-persist_period",
+              "type": "integer"
+            },
+            "restart_period": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-restart_period",
+              "type": "integer"
+            },
+            "cluster_stabilization_period": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-cluster_stabilization_period",
+              "type": "integer"
+            },
+            "single_task_err_threshold": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-single_task_err_threshold",
+              "type": "integer"
+            },
+            "max_parallel_repairs": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-max_parallel_repairs",
+              "type": "integer"
+            },
+            "max_pending_repairs": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-max_pending_repairs",
+              "type": "integer"
+            },
+            "single_repair_timeout": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-single_repair_timeout",
+              "type": "integer"
+            },
+            "min_repair_time": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-min_repair_time",
+              "type": "integer"
+            },
+            "min_throughput": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-min_throughput",
+              "type": "integer"
+            },
+            "num_recent_throughputs": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-num_recent_throughputs",
+              "type": "integer"
+            },
+            "error_logging_window": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-error_logging_window",
+              "type": "integer"
+            },
+            "incremental_repair_tables": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-incremental_repair_tables",
+              "type": "string"
+            },
+            "incremental_sleep": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-incremental_sleep",
+              "type": "integer"
+            },
+            "incremental_threshold": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-incremental_threshold",
+              "type": "integer"
+            },
+            "prioritization_page_size": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-prioritization_page_size",
+              "type": "integer"
+            },
+            "offline_splits": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-offline_splits",
+              "type": "integer"
+            },
+            "ignore_keyspaces": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-ignore_keyspaces",
+              "type": "string"
+            },
+            "ignore_table": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-ignore_table",
+              "type": "string"
+            },
+            "time_to_completion_target_percentage": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-time_to_completion_target_percentage",
+              "type": "number"
+            },
+            "incremental_repair_datacenters": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-incremental_repair_datacenters",
+              "type": "string"
+            },
+            "tokenranges_http_timeout": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-tokenranges_http_timeout",
+              "type": "integer"
+            },
+            "max_down_node_retry": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-max_down_node_retry",
+              "type": "integer"
+            },
+            "incremental_err_alert_threshold": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-incremental_err_alert_threshold",
+              "type": "integer"
+            },
+            "snapshot_override": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__repair_service-snapshot_override",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "ui": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ui",
+          "type": "object",
+          "properties": {
+            "default_api_timeout": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ui-default_api_timeout",
+              "type": "integer"
+            },
+            "max_metrics_requests": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ui-max_metrics_requests",
+              "type": "integer"
+            },
+            "node_detail_refresh_delay": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ui-node_detail_refresh_delay",
+              "type": "integer"
+            },
+            "storagemap_ttl": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__ui-storagemap_ttl",
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "request_tracker": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__request_tracker",
+          "type": "object",
+          "properties": {
+            "queue_size": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__request_tracker-queue_size",
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "clusters": {
+          "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__clusters",
+          "type": "object",
+          "properties": {
+            "add_cluster_timeout": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__clusters-add_cluster_timeout",
+              "type": "integer"
+            },
+            "startup_sleep": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__clusters-startup_sleep",
+              "type": "integer"
+            },
+            "max_schema_agreement_wait": {
+              "id": "http://docs.datastax.com/en/latest-opscenter/opsc/configure/opscConfigProps_r.html#opscConfigProps__clusters-max_schema_agreement_wait",
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "heap",
+        "disk",
+        "portworx_volume_name",
+        "gui_port"
+      ]
+    },
+    "dse": {
+      "description": "DSE node properties",
+      "type": "object",
+      "properties": {
+        "cluster_name": {
+          "title": "DSE cluster name",
+          "type": "string",
+          "default": "cluster_datastax"
+        },
+        "seed_hostname1": {
+          "title": "First DSE seed node hostname",
+          "type": "string",
+          "default": "dse-0-node.portworx-datastax-dse.autoip.dcos.thisdcos.directory"
+        },
+        "seed_hostname2": {
+          "title": "Second DSE seed node hostname",
+          "type": "string",
+          "default": "dse-1-node.portworx-datastax-dse.autoip.dcos.thisdcos.directory"
+        },
+        "jmx_port": {
+          "title": "JMX monitoring port",
+          "type": "integer",
+          "default": 7199
+        },
+        "agent_port": {
+          "title": "Agent API port",
+          "type": "integer",
+          "default": 21621
+        },
+        "native_port": {
+          "title": "Cassandra native client port",
+          "type": "integer",
+          "default": 9042
+        },
+        "thrift_port": {
+          "title": "Cassandra thrift client port",
+          "type": "integer",
+          "default": 9160
+        },
+        "spark_master_webui_port": {
+          "title": "Spark master web UI port",
+          "type": "integer",
+          "default": 7080
+        }
+      },
+      "required": [
+        "jmx_port",
+        "agent_port",
+        "native_port",
+        "thrift_port",
+        "cluster_name",
+        "spark_master_webui_port"
+      ],
+      "extraProperties": false
+    }
+  }
+}

--- a/repo/packages/P/portworx-datastax-ops/0/marathon.json.mustache
+++ b/repo/packages/P/portworx-datastax-ops/0/marathon.json.mustache
@@ -1,0 +1,240 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M\" && ./bootstrap -resolve=false -template=false && env && ./portworx-datastax-ops-scheduler/bin/datastax-ops ./portworx-datastax-ops-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http",
+    "MARATHON_SINGLE_INSTANCE_APP":"true"
+  },
+  {{#service.service_secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_secret_name}}"
+    }
+  },
+  {{/service.service_secret_name}}
+  "env": {
+    "PACKAGE_NAME": "portworx-datastax-ops",
+    "PACKAGE_VERSION": "1.2-2.3.0-6.1.2",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1534812560729",
+    "PACKAGE_BUILD_TIME_STR": "Tue Aug 21 2018 00:49:20 +0000",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "TASKCFG_ALL_DS_LICENSE": "accept",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "SERVICE_USER": "{{service.user}}",
+    "SERVICE_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "OPSCENTER_DOCKER_IMAGE": "{{resource.assets.container.docker.opscenter}}",
+
+    {{#service.virtual_networks}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME_OPSCENTER": "{{opscenter.virtual_network}}",
+    "CNI_PLUGIN_LABELS_OPSCENTER": "{{opscenter.cni_plugin_labels}}",
+    {{/service.virtual_networks}}
+
+    {{#service.service_secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_secret_name}}
+
+    "OPSC_CASSANDRA_USERNAME": "{{opscenter.cassandra_username}}",
+    "OPSC_CASSANDRA_PASSWORD": "{{opscenter.cassandra_password}}",
+    "OPSCENTER_INSTALL_DIR": "opscenter",
+    "DSE_INSTALL_DIR": "dse",
+
+    "DSE_CLUSTER_NAME": "{{cluster.cluster_name}}",
+    "DSE_DC_NAME": "{{cluster.dc_name}}",
+    "DSE_RACK_NAME": "rack1",
+
+    {{#service.security.transport_encryption.enabled}}
+    "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "true",
+    {{/service.security.transport_encryption.enabled}}
+
+    {{#service.region}}
+    "SERVICE_REGION": "{{service.region}}",
+    {{/service.region}}
+
+    "OPSCENTER_PLACEMENT": "{{{opscenter.placement_constraint}}}",
+    "OPSCENTER_CPUS": "{{opscenter.cpus}}",
+    "OPSCENTER_MEM": "{{opscenter.mem}}",
+    "OPSCENTER_HEAP": "{{opscenter.heap}}",
+    "OPSCENTER_JVM_OPTS": "{{{opscenter.jvm_opts}}}",
+    "OPSCENTER_DISK": "{{opscenter.disk}}",
+    "OPSCENTER_DISK_TYPE": "{{opscenter.disk_type}}",
+    "OPSCENTER_DISK_DOCKER_VOLUME_NAME": "{{{opscenter.portworx_volume_name}}}",
+    "OPSCENTER_DISK_DOCKER_VOLUME_OPTIONS": "{{{opscenter.portworx_volume_options}}}",
+
+    {{#service.security.transport_encryption.enabled}}
+    "OPSCENTER_GUI_PORT": "{{opscenter.webserver.ssl_port}}",
+    {{/service.security.transport_encryption.enabled}}
+
+    {{^service.security.transport_encryption.enabled}}
+    "OPSCENTER_GUI_PORT": "{{opscenter.gui_port}}",
+    {{/service.security.transport_encryption.enabled}}
+
+    "OPSCENTER_STOMP_PORT": "{{opscenter.stomp_port}}",
+    "OPSCENTER_SPARK_MASTER_PROXY_PORT": "{{opscenter.spark_master_proxy_port}}",
+
+    "OPSC_AUTHENTICATION_METHOD": "{{opscenter.authentication.method}}",
+    "OPSC_AUTHENTICATION_PASSWD_DB": "./passwd_db/passwd.db",
+
+    "OPSC_WEBSERVER_STATICDIR": "{{opscenter.webserver.staticdir}}",
+    "OPSC_WEBSERVER_SUB_PROCESS_TIMEOUT": "{{opscenter.webserver.sub_process_timeout}}",
+
+    "OPSC_HTTP_PROXY_SETTINGS_PROXY_URL": "{{opscenter.http_proxy_settings.proxy_url}}",
+    "OPSC_HTTP_PROXY_SETTINGS_PROXY_USERNAME": "{{opscenter.http_proxy_settings.proxy_username}}",
+    "OPSC_HTTP_PROXY_SETTINGS_PROXY_PASSWORD": "{{opscenter.http_proxy_settings.proxy_password}}",
+
+    "OPSC_LOGGING_RESOURCE_USAGE_INTERVAL": "{{opscenter.logging.resource_usage_interval}}",
+
+    "OPSC_DEFINITIONS_DEFINITIONS_DIR": "{{opscenter.definitions.definitions_dir}}",
+    "OPSC_DEFINITIONS_AUTO_UPDATE": "{{opscenter.definitions.auto_update}}",
+    "OPSC_DEFINITIONS_DOWNLOAD_HOST": "{{opscenter.definitions.download_host}}",
+    "OPSC_DEFINITIONS_DOWNLOAD_PORT": "{{opscenter.definitions.download_port}}",
+    "OPSC_DEFINITIONS_DOWNLOAD_FILENAME": "{{opscenter.definitions.download_filename}}",
+    "OPSC_DEFINITIONS_HASH_FILENAME": "{{opscenter.definitions.hash_filename}}",
+    "OPSC_DEFINITIONS_SLEEP": "{{opscenter.definitions.sleep}}",
+
+    "OPSC_AGENTS_CONFIG_SLEEP": "{{opscenter.agents.config_sleep}}",
+    "OPSC_AGENTS_AGENT_INSTALL_POLL_PERIOD": "{{opscenter.agents.agent_install_poll_period}}",
+    "OPSC_AGENTS_AGENT_INSTALL_MUTE_PERIOD": "{{opscenter.agents.agent_install_mute_period}}",
+    "OPSC_AGENTS_AGENT_INSTALL_TIMEOUT_PERIOD": "{{opscenter.agents.agent_install_timeout_period}}",
+    "OPSC_AGENTS_SSH_EXECUTABLE": "{{opscenter.agents.ssh_executable}}",
+    "OPSC_AGENTS_SCP_EXECUTABLE": "{{opscenter.agents.scp_executable}}",
+    "OPSC_AGENTS_SSH_KEYGEN_EXECUTABLE": "{{opscenter.agents.ssh_keygen_executable}}",
+    "OPSC_AGENTS_SSH_KEYSCAN_EXECUTABLE": "{{opscenter.agents.ssh_keyscan_executable}}",
+    "OPSC_AGENTS_SSH_USER_KNOWN_HOSTS_FILE": "{{opscenter.agents.ssh_user_known_hosts_file}}",
+    "OPSC_AGENTS_SSH_SYS_KNOWN_HOSTS_FILE": "{{opscenter.agents.ssh_sys_known_hosts_file}}",
+    "OPSC_AGENTS_TMP_DIR": "{{opscenter.agents.ssh_tmp_dir}}",
+    "OPSC_AGENTS_NOT_SEEN_THRESHOLD": "{{opscenter.agents.not_seen_threshold}}",
+    "OPSC_AGENTS_CALL_AGENT_RETRY": "{{opscenter.agents.call_agent_retry}}",
+    "OPSC_AGENTS_AGENT_AGGREGATION_FLUSH": "{{opscenter.agents.agent_aggregation_flush}}",
+    "OPSC_AGENTS_HTTP_POLL_PERIOD": "{{opscenter.agents.http_poll_period}}",
+    "OPSC_AGENTS_PATH_TO_INSTALL_SCRIPT": "{{opscenter.agents.path_to_install_script}}",
+    "OPSC_AGENTS_PATH_TO_SUDOWRAP": "{{opscenter.agents.path_to_sudowrap}}",
+
+    "OPSC_STAT_REPORTER_INITIAL_SLEEP": "{{opscenter.stat_reporter.initial_sleep}}",
+    "OPSC_STAT_REPORTER_INTERVAL": "{{opscenter.stat_reporter.interval}}",
+
+    "OPSC_REPAIR_SERVICE_PERSIST_DIRECTORY": "{{opscenter.repair_service.persist_directory}}",
+    "OPSC_REPAIR_SERVICE_PERSIST_PERIOD": "{{opscenter.repair_service.persist_period}}",
+    "OPSC_REPAIR_SERVICE_RESTART_PERIOD": "{{opscenter.repair_service.restart_period}}",
+    "OPSC_REPAIR_SERVICE_CLUSTER_STABILIZATION_PERIOD": "{{opscenter.repair_service.cluster_stabilization_period}}",
+    "OPSC_REPAIR_SERVICE_SINGLE_TASK_ERR_THRESHOLD": "{{opscenter.repair_service.single_task_err_threshold}}",
+    "OPSC_REPAIR_SERVICE_MAX_PARALLEL_REPAIRS": "{{opscenter.repair_service.max_parallel_repairs}}",
+    "OPSC_REPAIR_SERVICE_MAX_PENDING_REPAIRS": "{{opscenter.repair_service.max_pending_repairs}}",
+    "OPSC_REPAIR_SERVICE_SINGLE_REPAIR_TIMEOUT": "{{opscenter.repair_service.single_repair_timeout}}",
+    "OPSC_REPAIR_SERVICE_MIN_REPAIR_TIME": "{{opscenter.repair_service.min_repair_time}}",
+    "OPSC_REPAIR_SERVICE_MIN_THROUGHPUT": "{{opscenter.repair_service.min_throughput}}",
+    "OPSC_REPAIR_SERVICE_NUM_RECENT_THROUGHPUTS": "{{opscenter.repair_service.num_recent_throughputs}}",
+    "OPSC_REPAIR_SERVICE_ERROR_LOGGING_WINDOW": "{{opscenter.repair_service.error_logging_window}}",
+    "OPSC_REPAIR_SERVICE_INCREMENTAL_REPAIR_TABLES": "{{opscenter.repair_service.incremental_repair_tables}}",
+    "OPSC_REPAIR_SERVICE_INCREMENTAL_ERR_ALERT_THRESHOLD": "{{opscenter.repair_service.incremental_err_alert_threshold}}",
+    "OPSC_REPAIR_SERVICE_SNAPSHOT_OVERRIDE": "{{opscenter.repair_service.snapshot_override}}",
+    "OPSC_REPAIR_SERVICE_INCREMENTAL_SLEEP": "{{opscenter.repair_service.incremental_sleep}}",
+    "OPSC_REPAIR_SERVICE_INCREMENTAL_THRESHOLD": "{{opscenter.repair_service.incremental_threshold}}",
+    "OPSC_REPAIR_SERVICE_PRIORITIZATION_PAGE_SIZE": "{{opscenter.repair_service.prioritization_page_size}}",
+    "OPSC_REPAIR_SERVICE_OFFLINE_SPLITS": "{{opscenter.repair_service.offline_splits}}",
+    "OPSC_REPAIR_SERVICE_IGNORE_KEYSPACES": "{{opscenter.repair_service.ignore_keyspaces}}",
+    "OPSC_REPAIR_SERVICE_IGNORE_TABLE": "{{opscenter.repair_service.ignore_table}}",
+    "OPSC_REPAIR_SERVICE_TIME_TO_COMPLETION_TARGET_PERCENTAGE": "{{opscenter.repair_service.time_to_completion_target_percentage}}",
+    "OPSC_REPAIR_SERVICE_INCREMENTAL_REPAIR_DATACENTERS": "{{opscenter.repair_service.incremental_repair_datacenters}}",
+    "OPSC_REPAIR_SERVICE_TOKENRANGES_HTTP_TIMEOUT": "{{opscenter.repair_service.tokenranges_http_timeout}}",
+    "OPSC_REPAIR_SERVICE_MAX_DOWN_NODE_RETRY": "{{opscenter.repair_service.max_down_node_retry}}",
+
+    "OPSC_UI_DEFAULT_API_TIMEOUT": "{{opscenter.ui.default_api_timeout}}",
+    "OPSC_UI_MAX_METRICS_REQUESTS": "{{opscenter.ui.max_metrics_requests}}",
+    "OPSC_UI_NODE_DETAIL_REFRESH_DELAY": "{{opscenter.ui.node_detail_refresh_delay}}",
+    "OPSC_UI_STORAGEMAP_TTL": "{{opscenter.ui.storagemap_ttl}}",
+
+    "OPSC_REQUEST_TRACKER_QUEUE_SIZE": "{{opscenter.request_tracker.queue_size}}",
+
+    "OPSC_CLUSTERS_ADD_CLUSTER_TIMEOUT": "{{opscenter.clusters.add_cluster_timeout}}",
+    "OPSC_CLUSTERS_STARTUP_SLEEP": "{{opscenter.clusters.startup_sleep}}",
+    "OPSC_CLUSTERS_MAX_SCHEMA_AGREEMENT_WAIT": "{{opscenter.clusters.max_schema_agreement_wait}}",
+
+{{#opscenter.authentication.enabled}}
+    "OPSC_AUTHENTICATION_ENABLED": "DEFINITELY",
+    "OPSC_AUTHENTICATION_LOGIN_USER": "{{opscenter.authentication.login_user}}",
+    "OPSC_AUTHENTICATION_LOGIN_PASSWORD": "{{opscenter.authentication.login_password}}",
+    "OPSC_AUTHENTICATION_TIMEOUT": "{{opscenter.authentication.timeout}}",
+    "OPSC_AUTHENTICATION_PASSWORD_HASH_TYPE": "{{opscenter.authentication.password_hash_type}}",
+    "OPSC_AUTHENTICATION_SQLITE_CONNECTION_TIMEOUT": "{{opscenter.authentication.sqlite_connection_timeout}}",
+    "OPSC_AUTHENTICATION_SQLITE_MAX_ACTIVE_CONNECTIONS": "{{opscenter.authentication.sqlite_max_active_connections}}",
+{{/opscenter.authentication.enabled}}
+
+{{#opscenter.ldap.enabled}}
+    "OPSC_LDAP_ENABLED": "DEFINITELY",
+    "OPSC_LDAP_SERVER_HOST": "{{opscenter.ldap.server_host}}",
+    "OPSC_LDAP_SERVER_PORT": "{{opscenter.ldap.server_port}}",
+    "OPSC_LDAP_SEARCH_DN": "{{{opscenter.ldap.search_dn}}}",
+    "OPSC_LDAP_SEARCH_PASSWORD": "{{opscenter.ldap.search_password}}",
+    "OPSC_LDAP_USER_SEARCH_BASE": "{{{opscenter.ldap.user_search_base}}}",
+    "OPSC_LDAP_USER_SEARCH_FILTER": "{{{opscenter.ldap.user_search_filter}}}",
+    "OPSC_LDAP_USER_MEMBEROF_ATTRIBUTE": "{{opscenter.ldap.user_memberof_attribute}}",
+    "OPSC_LDAP_GROUP_SEARCH_TYPE": "{{{opscenter.ldap.group_search_type}}}",
+    "OPSC_LDAP_GROUP_SEARCH_BASE": "{{{opscenter.ldap.group_search_base}}}",
+    "OPSC_LDAP_GROUP_SEARCH_FILTER_WITH_DN": "{{{opscenter.ldap.group_search_filter_with_dn}}}",
+    "OPSC_LDAP_GROUP_NAME_ATTRIBUTE": "{{{opscenter.ldap.group_name_attribute}}}",
+    "OPSC_LDAP_ADMIN_GROUP_NAME": "{{{opscenter.ldap.admin_group_name}}}",
+    "OPSC_LDAP_LDAP_SECURITY": "{{opscenter.ldap.ldap_security}}",
+    "OPSC_LDAP_CONNECTION_TIMEOUT": "{{opscenter.ldap.connection_timeout}}",
+{{/opscenter.ldap.enabled}}
+
+    "DSE_SEED_NODE_HOSTNAME0": "{{dse.seed_hostname1}}",
+    "DSE_SEED_NODE_HOSTNAME1": "{{dse.seed_hostname2}}",
+    "DSE_CLUSTER_NAME": "{{dse.cluster_name}}",
+    "DSE_JMX_PORT": "{{dse.jmx_port}}",
+    "DSE_AGENT_PORT": "{{dse.agent_port}}",
+    "DSE_NATIVE_PORT": "{{dse.native_port}}",
+    "DSE_THRIFT_PORT": "{{dse.thrift_port}}",
+    "DSE_SPARK_MASTER_WEBUI_PORT": "{{dse.spark_master_webui_port}}",
+
+    "INIT_CLUSTER_URI": "{{resource.assets.uris.opscenter-init-zip}}",
+
+    "CONFIG_TEMPLATE_PATH": "datastax-ops-scheduler"
+  },
+  "fetch": [
+    { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },
+    { "uri": "{{resource.assets.uris.jre-tar-gz}}", "cache": true },
+    { "uri": "{{resource.assets.uris.scheduler-zip}}", "cache": true },
+    { "uri": "{{resource.assets.uris.libmesos-bundle-tar-gz}}", "cache": true }
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+   {
+     "protocol": "MESOS_HTTP",
+     "path": "/v1/health",
+     "gracePeriodSeconds": 900,
+     "intervalSeconds": 30,
+     "portIndex": 0,
+     "timeoutSeconds": 30,
+     "maxConsecutiveFailures": 0
+   }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-datastax-ops/0/package.json
+++ b/repo/packages/P/portworx-datastax-ops/0/package.json
@@ -1,0 +1,29 @@
+{
+  "packagingVersion": "4.0",
+  "name": "portworx-datastax-ops",
+  "version": "1.2-2.3.0-6.1.2",
+  "upgradesFrom": [
+    ""
+  ],
+  "downgradesTo": [
+    ""
+  ],
+  "maintainer": "support@portworx.com",
+  "minDcosReleaseVersion": "1.9",
+  "description": "Datastax Enterprise OpsCenter backed by Portworx volumes",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "datastax",
+    "dse",
+    "opscenter",
+    "management",
+    "enterprise",
+    "nosql",
+    "database",
+    "portworx"
+  ],
+  "preInstallNotes": "This DC/OS Service is maintained by Portwor.\n\nFunctionality supported in Opscenter includes Repair, Monitoring, Backup & Restore, as well as some basic admin tools including cleanup, restart, and drain. No other OpsCenter functionality is tested or supported within the DC/OS Integration.\n\nDefault configuration requires 1 agent node with: 2.5 CPU | 4100 MB MEM | 10240 MB Disk.\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nVersions: DataStax Enterprise 5.1.2 (Standard and Max) & OpsCenter 6.1.2",
+  "postInstallNotes": "DC/OS Datastax Enterprise is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/dse/2.3.0-5.1.2\n\tIssues: support@portworx.com",
+  "postUninstallNotes": "DC/OS Datastax Enterprise OpsCenter is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/dse/v2.0.0-5.1.2/uninstall/ to remove any persistent state if required."
+}

--- a/repo/packages/P/portworx-datastax-ops/0/resource.json
+++ b/repo/packages/P/portworx-datastax-ops/0/resource.json
@@ -1,0 +1,62 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "opscenter": "dspn/10517a0c8e9b11e79ef5600308a463ab-2:6.1.2"
+      }
+    },
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u172-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
+      "opscenter-init-zip": "https://px-dcos.s3.amazonaws.com/portworx-datastax-ops/assets/1.2-2.3.0-6.1.2/opscenter-init.zip",
+      "bootstrap-zip": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.2.2/bootstrap.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-datastax-ops/assets/1.2-2.3.0-6.1.2/portworx-datastax-ops-scheduler.zip",
+      "executor-zip": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.2.2/executor.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Small.jpg",
+    "icon-medium": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Medium.jpg",
+    "icon-large": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Big.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "5c37e71d56b788797f6b4aea8da32c20cd809f8647fabd130681ea11b038ef9a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.2.2/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "0e00e9159a85a5d3c744be888aa32b47f86fc1f64adac579bb4c0b481468b5e8"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.2.2/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "d44418b214d39943874cb99d7529b8e4ded92fc6997142a15caff6cff31cbbec"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.2.2/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx-datastax-ops 1.2-2.3.0-6.1.2 (automated commit)

Description:
Source URL: https://disrani-dcos.s3.amazonaws.com/v1/portworx-datastax-ops/20180820-174918-xB00ylHdkOk2rbj5/stub-universe-portworx-datastax-ops.json

Changes between revisions -1 => 0:
4 files added: [resource.json, package.json, marathon.json.mustache, config.json]
0 files removed: []
0 files changed:

```
```
