### PR TITLE
Release jenkins 3.5.2-2.107.2 (automated commit)



### DIFF
--- a/repo/packages/J/jenkins/100/config.json
+++ b/repo/packages/J/jenkins/100/config.json
@@ -1,0 +1,153 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "description": "Configuration properties for the Jenkins service for DC/OS.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the service to display in the DC/OS dashboard.",
+          "type": "string",
+          "default": "portworx-jenkins"
+        },
+        "cpus": {
+          "description": "CPU shares to allocate to each Jenkins master.",
+          "type": "number",
+          "default": 1.0,
+          "minimum": 0.1
+        },
+        "mem": {
+          "description": "Memory (in MB) to allocate to each Jenkins master.",
+          "type": "number",
+          "default": 4096.0,
+          "minimum": 2048.0
+        },
+        "user": {
+          "description": "The user that the service will run as. In 'strict' security mode, running tasks as root is disabled by default. Ensure that this user exists on each of the agents in your DC/OS cluster.",
+          "type": "string",
+          "default": "root"
+        }
+      },
+      "required": [
+        "name",
+        "cpus",
+        "mem"
+      ]
+    },
+    "storage": {
+      "description": "Storage-related configuration properties for Jenkins on DC/OS.",
+      "type": "object",
+      "properties": {
+        "pinned-hostname": {
+          "description": "An optional DC/OS agent hostname to run this Jenkins instance on (e.g. 10.0.0.1).",
+          "type": "string"
+        },
+        "portworx-volume-name": {
+          "description": "Name of the Portworx volume.",
+          "type": "string",
+          "default": "jenkins-master"
+        },
+        "portworx-volume-size": {
+          "description": "Size of the Portworx volume in GB.",
+          "type": "number",
+          "default": 10
+        },
+        "portworx-volume-replication-factor": {
+          "description": "Replication factor of the Portworx volume.",
+          "type": "number",
+          "minimum": 1,
+          "maximum": 3,
+          "default": 1
+        }
+      },
+      "required": [
+        "portworx-volume-name"
+      ]
+    },
+    "networking": {
+      "description": "Networking-related configuration properties for Jenkins on DC/OS.",
+      "type": "object",
+      "properties": {
+        "known-hosts": {
+          "description": "A space-separated list of hosts used to populate the SSH known hosts file on the Jenkins master.",
+          "type": "string",
+          "default": "github.com"
+        },
+        "virtual-host": {
+          "description": "The virtual host address to configure for integration with Marathon-lb.",
+          "type": "string"
+        },
+        "https-redirect": {
+          "description": "Whether Marathon-lb should redirect HTTP traffic to HTTPS. This requires 'virtual-host' to be set. By default, this is false.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "roles": {
+      "description": "Role configuration properties for Jenkins on DC/OS.",
+      "type": "object",
+      "properties": {
+        "jenkins-master-role": {
+          "description": "The accepted resource roles that the Jenkins master itself runs as using Marathon. By default, this will deploy to any agents with the * role. For example, to deploy to a public DC/OS agent, set this to 'slave_public'.",
+          "type": "string",
+          "default": "*"
+        },
+        "jenkins-agent-role": {
+          "description": "The role passed to the internal Jenkins configuration that denotes which resources to launch Jenkins agents on.",
+          "type": "string",
+          "default": "*"
+        }
+      }
+    },
+    "security": {
+      "description": "Security configuration properties for Jenkins on DC/OS.",
+      "type": "object",
+      "properties": {
+        "strict-mode": {
+          "description": "Enabled if Enterprise DC/OS is provisioned using the 'strict' security mode flag. When enabled, tasks run as the user specified below.",
+          "type": "boolean",
+          "default": false
+        },
+        "secret-name": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "advanced": {
+      "description": "Advanced configuration properties for the Jenkins service. Under normal circumstances, you shouldn't need to modify these values.",
+      "type": "object",
+      "properties": {
+        "mesos-master": {
+          "description": "URL of this cluster's Mesos master.",
+          "type": "string",
+          "default": "zk://leader.mesos:2181/mesos"
+        },
+        "jvm-opts": {
+          "description": "Optional arguments to pass to the JVM.",
+          "type": "string",
+          "default": "-Xms1024m -Xmx1024m"
+        },
+        "jenkins-opts": {
+          "description": "Optional arguments to pass to Jenkins.",
+          "type": "string"
+        },
+        "docker-image": {
+          "description": "The Docker image to use for the Jenkins service. By default, this package will use the Jenkins image in the Mesosphere organization on Docker Hub, which you must be authenticated against. Otherwise, specify the host, image, and tag for the Jenkins image on your private Docker Registry.",
+          "type": "string"
+        },
+        "docker-credentials-uri": {
+          "description": "An optional URI to be fetched and extracted that contains docker credentials (e.g. file:///etc/docker/docker.tar.gz).",
+          "type": "string"
+        },
+        "prometheus-endpoint": {
+          "description": "An optional, relative URL path to be used by Prometheus. (e.g. 'prometheus/metrics')",
+          "type": "string",
+          "default": "v1/metrics/prometheus"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/J/jenkins/100/marathon.json.mustache
+++ b/repo/packages/J/jenkins/100/marathon.json.mustache
@@ -1,0 +1,99 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": 1,
+  {{#security.secret-name}}
+  "secrets": {
+      "serviceCredential": {
+          "source": "{{security.secret-name}}"
+      }
+  },
+  {{/security.secret-name}}
+  "env": {
+      "JENKINS_AGENT_ROLE": "{{roles.jenkins-agent-role}}",
+      "JENKINS_AGENT_USER": "{{service.user}}",
+      "JENKINS_FRAMEWORK_NAME": "{{service.name}}",
+      {{#security.secret-name}}
+        "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+        "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+        "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+        "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+      {{/security.secret-name}}
+      "JENKINS_CONTEXT": "/service/{{service.name}}",
+      "JENKINS_MESOS_MASTER": "{{advanced.mesos-master}}",
+      {{#networking.virtual-host}}
+      "JENKINS_ROOT_URL": "{{#networking.https-redirect}}https://{{/networking.https-redirect}}{{^networking.https-redirect}}http://{{/networking.https-redirect}}{{networking.virtual-host}}/service/{{service.name}}",
+      {{/networking.virtual-host}}
+      "JENKINS_HOME":"/mnt/mesos/sandbox/jenkins_home",
+      "JVM_OPTS": "{{advanced.jvm-opts}}",
+      "JENKINS_OPTS": "{{advanced.jenkins-opts}}",
+      "PROMETHEUS_ENDPOINT": "{{advanced.prometheus-endpoint}}",
+      "SSH_KNOWN_HOSTS": "{{networking.known-hosts}}",
+      "MARATHON_NAME": "marathon"
+  },
+  "portDefinitions": [
+      {"port": 0, "protocol": "tcp", "name": "nginx"},
+      {"port": 0, "protocol": "tcp", "name": "jenkins"},
+      {"port": 0, "protocol": "tcp", "name": "agent"}
+  ],
+  "container": {
+        "type": "MESOS",
+        "docker": {
+          "image": "{{resource.assets.container.docker.jenkins}}"
+        },
+        "volumes": [
+            {
+              "external": {
+                "size": {{storage.portworx-volume-size}},
+                "name": "{{storage.portworx-volume-name}}",
+                "provider": "dvdi",
+                "options": {
+                  "dvdi/driver": "pxd",
+                  "dvdi/repl": "{{storage.portworx-volume-replication-factor}}"
+                }
+              },
+              "mode": "RW",
+              "containerPath": "jenkins_home"
+            }
+        ]
+   },
+   {{#advanced.docker-credentials-uri}}
+   "fetch": [
+      {
+          "uri": "{{advanced.docker-credentials-uri}}",
+          "executable": false,
+          "extract": true
+      }
+   ],{{/advanced.docker-credentials-uri}}
+   "acceptedResourceRoles": [ "{{roles.jenkins-master-role}}" ],
+   "healthChecks": [
+    {
+      "path": "/service/{{service.name}}",
+      "portIndex": 0,
+      "protocol": "MESOS_HTTP",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 5
+    }
+  ],
+  "labels": {
+    {{#networking.virtual-host}}
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_VHOST":"{{networking.virtual-host}}",
+    "HAPROXY_0_REDIRECT_TO_HTTPS": "{{networking.https-redirect}}",
+    {{/networking.virtual-host}}
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }{{#storage.pinned-hostname}},
+  "constraints": [["hostname", "CLUSTER", "{{storage.pinned-hostname}}"]]
+  {{/storage.pinned-hostname}}
+}

--- a/repo/packages/J/jenkins/100/package.json
+++ b/repo/packages/J/jenkins/100/package.json
@@ -1,0 +1,27 @@
+{
+  "packagingVersion": "3.0",
+  "name": "jenkins",
+  "version": "3.5.2-2.107.2",
+  "minDcosReleaseVersion": "1.9",
+  "scm": "https://github.com/portworx/dcos-jenkins-service.git",
+  "maintainer": "support@portworx.com",
+  "website": "https://www.portworx.com",
+  "framework": true,
+  "description": "Jenkins is an award-winning, cross-platform, continuous integration and continuous delivery application that increases your productivity. Use Jenkins to build and test your software projects continuously making it easier for developers to integrate changes to the project, and making it easier for users to obtain a fresh build. It also allows you to continuously deliver your software by providing powerful ways to define your build pipelines and integrating with a large number of testing and deployment technologies.",
+  "tags": [
+    "continuous-integration",
+    "ci",
+    "jenkins",
+    "portworx"
+  ],
+  "preInstallNotes": "WARNING: If you didn't provide a value for `storage.portworx-volume-name` (either using the CLI or via the Advanced Install dialog),\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n",
+  "postInstallNotes": "Jenkins has been installed.",
+  "postUninstallNotes": "Jenkins has been uninstalled. Note that any data persisted to Portworx volume still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/mesosphere/dcos-jenkins-service/blob/master/LICENSE"
+    }
+  ],
+  "selected": false
+}

--- a/repo/packages/J/jenkins/100/resource.json
+++ b/repo/packages/J/jenkins/100/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/jenkins-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/jenkins-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/jenkins-icon-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "jenkins": "mesosphere/jenkins:3.5.2-2.107.2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release jenkins 3.5.2-2.107.2 (automated commit)

Description:
Source URL: https://px-dcos-dev.s3.amazonaws.com/autodelete7d/jenkins/20181205-204908-iyAJHneYPQo2GdpF/stub-universe-jenkins.json

Changes between revisions 28 => 100:
0 files added: []
0 files removed: []
4 files changed:

```
--- 28/config.json
+++ 100/config.json
@@ -1,143 +1,153 @@
 {
-    "type": "object",
-    "properties": {
-        "service": {
-            "description": "Configuration properties for the Jenkins service for DC/OS.",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "description": "The name of the service to display in the DC/OS dashboard.",
-                    "type": "string",
-                    "default": "jenkins"
-                },
-                "cpus": {
-                    "description": "CPU shares to allocate to each Jenkins master.",
-                    "type": "number",
-                    "default": 1.0,
-                    "minimum": 0.1
-                },
-                "mem": {
-                    "description": "Memory (in MB) to allocate to each Jenkins master.",
-                    "type": "number",
-                    "default": 2048.0,
-                    "minimum": 2048.0
-                },
-                "user": {
-                    "description": "The user that the service will run as. In 'strict' security mode, running tasks as root is disabled by default. Ensure that this user exists on each of the agents in your DC/OS cluster.",
-                    "type": "string",
-                    "default": "root"
-                },
-                "marathon-name": {
-                    "description": "The name of the Marathon framework the Jenkins master is deployed from. Change when using a MoM (Marathon on Marathon).",
-                    "type": "string",
-                    "default": "marathon"
-                }
-            },
-            "required": [
-                "name",
-                "cpus",
-                "mem"
-            ]
+  "type": "object",
+  "properties": {
+    "service": {
+      "description": "Configuration properties for the Jenkins service for DC/OS.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the service to display in the DC/OS dashboard.",
+          "type": "string",
+          "default": "portworx-jenkins"
         },
-        "storage": {
-            "description": "Storage-related configuration properties for Jenkins on DC/OS.",
-            "type": "object",
-            "properties": {
-                "host-volume": {
-                    "description": "The location of a volume on the host to be used for persisting Jenkins configuration and build data. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/jenkins`). Note that this path must be the same on all DC/OS agents.",
-                    "type": "string",
-                    "default": "/tmp"
-                },
-                "pinned-hostname": {
-                    "description": "An optional DC/OS agent hostname to run this Jenkins instance on (e.g. 10.0.0.1).",
-                    "type" : "string"
-                }
-            }
+        "cpus": {
+          "description": "CPU shares to allocate to each Jenkins master.",
+          "type": "number",
+          "default": 1.0,
+          "minimum": 0.1
         },
-        "networking": {
-            "description": "Networking-related configuration properties for Jenkins on DC/OS.",
-            "type": "object",
-            "properties": {
-                "known-hosts": {
-                    "description": "A space-separated list of hosts used to populate the SSH known hosts file on the Jenkins master.",
-                    "type": "string",
-                    "default": "github.com"
-                },
-                "virtual-host": {
-                    "description": "The virtual host address to configure for integration with Marathon-lb.",
-                    "type": "string"
-                },
-                "https-redirect": {
-                    "description": "Whether Marathon-lb should redirect HTTP traffic to HTTPS. This requires 'virtual-host' to be set. By default, this is false.",
-                    "type": "boolean",
-                    "default": false
-                },
-                "agent-port": {
-                    "description": "The port that Jenkins agents will use to connect to the master. The default port is set to 50000; a value of 0 will result in a random port being chosen.",
-                    "type": "integer",
-                    "default": 50000
-                }
-            }
+        "mem": {
+          "description": "Memory (in MB) to allocate to each Jenkins master.",
+          "type": "number",
+          "default": 4096.0,
+          "minimum": 2048.0
         },
-        "roles": {
-            "description": "Role configuration properties for Jenkins on DC/OS.",
-            "type": "object",
-            "properties": {
-                "jenkins-master-role": {
-                    "description": "The accepted resource roles that the Jenkins master itself runs as using Marathon. By default, this will deploy to any agents with the * role. For example, to deploy to a public DC/OS agent, set this to 'slave_public'.",
-                    "type": "string",
-                    "default": "*"
-                },
-                "jenkins-agent-role": {
-                    "description": "The role passed to the internal Jenkins configuration that denotes which resources to launch Jenkins agents on.",
-                    "type": "string",
-                    "default": "*"
-                  }
-              }
-          },
-        "security": {
-            "description": "Security configuration properties for Jenkins on DC/OS.",
-            "type": "object",
-            "properties": {
-                "strict-mode": {
-                    "description": "Enabled if Enterprise DC/OS is provisioned using the 'strict' security mode flag. When enabled, tasks run as the user specified below.",
-                    "type": "boolean",
-                    "default": false
-                },
-                "secret-name": {
-                    "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
-                    "type": "string",
-                    "default": ""
-                }
-            }
+        "user": {
+          "description": "The user that the service will run as. In 'strict' security mode, running tasks as root is disabled by default. Ensure that this user exists on each of the agents in your DC/OS cluster.",
+          "type": "string",
+          "default": "root"
+        }
+      },
+      "required": [
+        "name",
+        "cpus",
+        "mem"
+      ]
+    },
+    "storage": {
+      "description": "Storage-related configuration properties for Jenkins on DC/OS.",
+      "type": "object",
+      "properties": {
+        "pinned-hostname": {
+          "description": "An optional DC/OS agent hostname to run this Jenkins instance on (e.g. 10.0.0.1).",
+          "type": "string"
         },
-        "advanced": {
-            "description": "Advanced configuration properties for the Jenkins service. Under normal circumstances, you shouldn't need to modify these values.",
-            "type": "object",
-            "properties": {
-                "mesos-master": {
-                    "description": "URL of this cluster's Mesos master.",
-                    "type": "string",
-                    "default": "zk://leader.mesos:2181/mesos"
-                },
-                "jvm-opts": {
-                    "description": "Optional arguments to pass to the JVM.",
-                    "type": "string",
-                    "default": "-Xms1024m -Xmx1024m"
-                },
-                "jenkins-opts": {
-                    "description": "Optional arguments to pass to Jenkins.",
-                    "type": "string"
-                },
-                "docker-image": {
-                    "description": "The Docker image to use for the Jenkins service. By default, this package will use the Jenkins image in the Mesosphere organization on Docker Hub, which you must be authenticated against. Otherwise, specify the host, image, and tag for the Jenkins image on your private Docker Registry.",
-                    "type": "string"
-                },
-                "docker-credentials-uri": {
-                    "description": "An optional URI to be fetched and extracted that contains docker credentials (e.g. file:///etc/docker/docker.tar.gz).",
-                    "type": "string"
-                }
-            }
+        "portworx-volume-name": {
+          "description": "Name of the Portworx volume.",
+          "type": "string",
+          "default": "jenkins-master"
+        },
+        "portworx-volume-size": {
+          "description": "Size of the Portworx volume in GB.",
+          "type": "number",
+          "default": 10
+        },
+        "portworx-volume-replication-factor": {
+          "description": "Replication factor of the Portworx volume.",
+          "type": "number",
+          "minimum": 1,
+          "maximum": 3,
+          "default": 1
         }
+      },
+      "required": [
+        "portworx-volume-name"
+      ]
+    },
+    "networking": {
+      "description": "Networking-related configuration properties for Jenkins on DC/OS.",
+      "type": "object",
+      "properties": {
+        "known-hosts": {
+          "description": "A space-separated list of hosts used to populate the SSH known hosts file on the Jenkins master.",
+          "type": "string",
+          "default": "github.com"
+        },
+        "virtual-host": {
+          "description": "The virtual host address to configure for integration with Marathon-lb.",
+          "type": "string"
+        },
+        "https-redirect": {
+          "description": "Whether Marathon-lb should redirect HTTP traffic to HTTPS. This requires 'virtual-host' to be set. By default, this is false.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "roles": {
+      "description": "Role configuration properties for Jenkins on DC/OS.",
+      "type": "object",
+      "properties": {
+        "jenkins-master-role": {
+          "description": "The accepted resource roles that the Jenkins master itself runs as using Marathon. By default, this will deploy to any agents with the * role. For example, to deploy to a public DC/OS agent, set this to 'slave_public'.",
+          "type": "string",
+          "default": "*"
+        },
+        "jenkins-agent-role": {
+          "description": "The role passed to the internal Jenkins configuration that denotes which resources to launch Jenkins agents on.",
+          "type": "string",
+          "default": "*"
+        }
+      }
+    },
+    "security": {
+      "description": "Security configuration properties for Jenkins on DC/OS.",
+      "type": "object",
+      "properties": {
+        "strict-mode": {
+          "description": "Enabled if Enterprise DC/OS is provisioned using the 'strict' security mode flag. When enabled, tasks run as the user specified below.",
+          "type": "boolean",
+          "default": false
+        },
+        "secret-name": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "advanced": {
+      "description": "Advanced configuration properties for the Jenkins service. Under normal circumstances, you shouldn't need to modify these values.",
+      "type": "object",
+      "properties": {
+        "mesos-master": {
+          "description": "URL of this cluster's Mesos master.",
+          "type": "string",
+          "default": "zk://leader.mesos:2181/mesos"
+        },
+        "jvm-opts": {
+          "description": "Optional arguments to pass to the JVM.",
+          "type": "string",
+          "default": "-Xms1024m -Xmx1024m"
+        },
+        "jenkins-opts": {
+          "description": "Optional arguments to pass to Jenkins.",
+          "type": "string"
+        },
+        "docker-image": {
+          "description": "The Docker image to use for the Jenkins service. By default, this package will use the Jenkins image in the Mesosphere organization on Docker Hub, which you must be authenticated against. Otherwise, specify the host, image, and tag for the Jenkins image on your private Docker Registry.",
+          "type": "string"
+        },
+        "docker-credentials-uri": {
+          "description": "An optional URI to be fetched and extracted that contains docker credentials (e.g. file:///etc/docker/docker.tar.gz).",
+          "type": "string"
+        },
+        "prometheus-endpoint": {
+          "description": "An optional, relative URL path to be used by Prometheus. (e.g. 'prometheus/metrics')",
+          "type": "string",
+          "default": "v1/metrics/prometheus"
+        }
+      }
     }
+  }
 }
--- 28/marathon.json.mustache
+++ 100/marathon.json.mustache
@@ -13,45 +13,50 @@
   "env": {
       "JENKINS_AGENT_ROLE": "{{roles.jenkins-agent-role}}",
       "JENKINS_AGENT_USER": "{{service.user}}",
-      "JENKINS_SLAVE_AGENT_PORT": "{{networking.agent-port}}",
       "JENKINS_FRAMEWORK_NAME": "{{service.name}}",
-      "MARATHON_NAME": "{{service.marathon-name}}",
       {{#security.secret-name}}
-          "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-          "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
-          "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+        "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+        "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+        "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+        "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
       {{/security.secret-name}}
       "JENKINS_CONTEXT": "/service/{{service.name}}",
       "JENKINS_MESOS_MASTER": "{{advanced.mesos-master}}",
       {{#networking.virtual-host}}
       "JENKINS_ROOT_URL": "{{#networking.https-redirect}}https://{{/networking.https-redirect}}{{^networking.https-redirect}}http://{{/networking.https-redirect}}{{networking.virtual-host}}/service/{{service.name}}",
       {{/networking.virtual-host}}
+      "JENKINS_HOME":"/mnt/mesos/sandbox/jenkins_home",
       "JVM_OPTS": "{{advanced.jvm-opts}}",
       "JENKINS_OPTS": "{{advanced.jenkins-opts}}",
-      "SSH_KNOWN_HOSTS": "{{networking.known-hosts}}"
+      "PROMETHEUS_ENDPOINT": "{{advanced.prometheus-endpoint}}",
+      "SSH_KNOWN_HOSTS": "{{networking.known-hosts}}",
+      "MARATHON_NAME": "marathon"
   },
   "portDefinitions": [
       {"port": 0, "protocol": "tcp", "name": "nginx"},
-      {"port": 0, "protocol": "tcp", "name": "jenkins"}
+      {"port": 0, "protocol": "tcp", "name": "jenkins"},
+      {"port": 0, "protocol": "tcp", "name": "agent"}
   ],
   "container": {
-       "type": "DOCKER",
-       "docker": {
-       {{#advanced.docker-image}}
-           "image": "{{advanced.docker-image}}",
-       {{/advanced.docker-image}}
-       {{^advanced.docker-image}}
-           "image": "{{resource.assets.container.docker.jenkins-352-21072}}",
-       {{/advanced.docker-image}}
-           "network" : "HOST"
-       },
-       "volumes": [
-           {
-               "containerPath": "/var/jenkins_home",
-               "hostPath": "{{storage.host-volume}}/{{service.name}}",
-               "mode": "RW"
-           }
-       ]
+        "type": "MESOS",
+        "docker": {
+          "image": "{{resource.assets.container.docker.jenkins}}"
+        },
+        "volumes": [
+            {
+              "external": {
+                "size": {{storage.portworx-volume-size}},
+                "name": "{{storage.portworx-volume-name}}",
+                "provider": "dvdi",
+                "options": {
+                  "dvdi/driver": "pxd",
+                  "dvdi/repl": "{{storage.portworx-volume-replication-factor}}"
+                }
+              },
+              "mode": "RW",
+              "containerPath": "jenkins_home"
+            }
+        ]
    },
    {{#advanced.docker-credentials-uri}}
    "fetch": [
@@ -66,11 +71,11 @@
     {
       "path": "/service/{{service.name}}",
       "portIndex": 0,
-      "protocol": "HTTP",
-      "gracePeriodSeconds": 30,
+      "protocol": "MESOS_HTTP",
+      "gracePeriodSeconds": 300,
       "intervalSeconds": 60,
       "timeoutSeconds": 20,
-      "maxConsecutiveFailures": 3
+      "maxConsecutiveFailures": 5
     }
   ],
   "labels": {
--- 28/package.json
+++ 100/package.json
@@ -3,20 +3,25 @@
   "name": "jenkins",
   "version": "3.5.2-2.107.2",
   "minDcosReleaseVersion": "1.9",
-  "scm": "https://github.com/mesosphere/dcos-jenkins-service.git",
-  "maintainer": "support@mesosphere.io",
-  "website": "https://jenkins.io",
+  "scm": "https://github.com/portworx/dcos-jenkins-service.git",
+  "maintainer": "support@portworx.com",
+  "website": "https://www.portworx.com",
   "framework": true,
   "description": "Jenkins is an award-winning, cross-platform, continuous integration and continuous delivery application that increases your productivity. Use Jenkins to build and test your software projects continuously making it easier for developers to integrate changes to the project, and making it easier for users to obtain a fresh build. It also allows you to continuously deliver your software by providing powerful ways to define your build pipelines and integrating with a large number of testing and deployment technologies.",
-  "tags": ["continuous-integration", "ci", "jenkins"],
-  "preInstallNotes": "WARNING: If you didn't provide a value for `storage.host-volume` (either using the CLI or via the Advanced Install dialog),\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n",
+  "tags": [
+    "continuous-integration",
+    "ci",
+    "jenkins",
+    "portworx"
+  ],
+  "preInstallNotes": "WARNING: If you didn't provide a value for `storage.portworx-volume-name` (either using the CLI or via the Advanced Install dialog),\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n",
   "postInstallNotes": "Jenkins has been installed.",
-  "postUninstallNotes": "Jenkins has been uninstalled. Note that any data persisted to a NFS share still exists and will need to be manually removed.",
+  "postUninstallNotes": "Jenkins has been uninstalled. Note that any data persisted to Portworx volume still exists and will need to be manually removed.",
   "licenses": [
     {
       "name": "Apache License Version 2.0",
       "url": "https://github.com/mesosphere/dcos-jenkins-service/blob/master/LICENSE"
     }
   ],
-  "selected": true
-}
+  "selected": false
+}--- 28/resource.json
+++ 100/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "jenkins-352-21072": "mesosphere/jenkins:3.5.2-2.107.2"
+        "jenkins": "mesosphere/jenkins:3.5.2-2.107.2"
       }
     }
   }
```
