### PR TITLE
Release portworx 1.3.5-2.0.3 (automated commit)



### DIFF
--- a/repo/packages/P/portworx/1200/config.json
+++ b/repo/packages/P/portworx/1200/config.json
@@ -1,0 +1,305 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "portworx"
+        },
+        "user": {
+          "description": "The user that runs the Portworx tasks.",
+          "type": "string",
+          "default": "root"
+        },
+        "principal": {
+          "title": "Custom principal (optional)",
+          "description": "The principal for the service instance, or empty to use the default.",
+          "type": "string",
+          "default": ""
+        },
+        "pre_reserved_role": {
+          "title": "Pre-reserved role (optional)",
+          "description": "The pre-reserved role to use for the tasks",
+          "type": "string",
+          "default": ""
+        },
+        "secret_name": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        },
+        "task_failure_timeout_minutes": {
+          "title": "Task failure timeout minutes",
+          "description": "If a task is in FAILED or LOST state for the set timeout (in minutes), the task will marked as permanently failed and new replacement task will be launched.",
+          "type": "integer",
+          "default": 5,
+          "minimum": 0
+        }
+      },
+      "required": [
+        "name",
+        "task_failure_timeout_minutes"
+      ]
+    },
+    "node": {
+      "description": "Portworx Node properties",
+      "type": "object",
+      "properties": {
+        "portworx_cluster": {
+          "title": "Portworx Cluster Name",
+          "type": "string",
+          "default": "portworx-dcos"
+        },
+        "portworx_image": {
+          "title": "Portworx Image name",
+          "type": "string",
+          "default": "portworx/px-enterprise:2.0.3"
+        },
+        "portworx_port_range_start": {
+          "title": "Portworx port range start",
+          "description": "Port number from which Portworx will start consuming ports. Cannot be updated once deployed.",
+          "type": "integer",
+          "default": 9001
+        },
+        "portworx_options": {
+          "title": "Portworx Options",
+          "type": "string",
+          "default": "-a -x mesos"
+        },
+        "internal_kvdb": {
+          "title": "Internal KVDB",
+          "description": "Portworx will internally create and manage a key-value store cluster. KVDB servers or package etcd will not be used if internal KVDB is enabled. Note: Do not change this once the cluster is up.",
+          "type": "boolean",
+          "default": false
+        },
+        "kvdb_servers": {
+          "title": "KVDB servers",
+          "description": "Comma seperated IP:PORT entries for the key value database (etcd or consul). If the etcd server is started using the package this will be ignored",
+          "type": "string",
+          "default": ""
+        },
+        "container_parameters": {
+          "title": "Container parameters",
+          "type": "string",
+          "description": "Any additional paramters to pass in to the Portworx container. For example environment variables can be passed in using \"-e\"",
+          "default": ""
+        },
+        "count": {
+          "title": "Node count",
+          "description": "Number of Portworx nodes to run",
+          "type": "integer",
+          "default": 3
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        }
+      },
+      "required": [
+        "count",
+        "portworx_cluster",
+        "portworx_image",
+        "portworx_port_range_start",
+        "portworx_options"
+      ]
+    },
+    "secrets": {
+      "description": "Use DC/OS Secrets for features like volume encryption, cloudsnap authentication, etc. This should be enabled only for DC/OS Enterprise edition. \nNote: DC/OS Secrets will only be supported from Portworx version 1.4",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable DC/OS secrets",
+          "description": "If enabled, provide valid credentials below, so that Portworx can access the secrets as needed",
+          "type": "boolean",
+          "default": false
+        },
+        "base_path": {
+          "title": "Secrets base path",
+          "description": "The secrets base path that is accessible to Portworx (DC/OS user provided to access secrets) for reading and writing secrets. If not provided, Portworx will look for secrets at the top level",
+          "type": "string",
+          "default": ""
+        },
+        "dcos_username_secret": {
+          "title": "DC/OS username secret",
+          "description": "Secret path containing the username of the DC/OS user who has permissions to access the secrets under the secrets base path. Eg. portworx/dcos_username",
+          "type": "string",
+          "default": "portworx/dcos_username"
+        },
+        "dcos_password_secret": {
+          "title": "DC/OS password secret",
+          "description": "Secret path containing the password of the DC/OS user who has permissions to access the secrets under the secrets base path. Eg. portworx/dcos_password",
+          "type": "string",
+          "default": "portworx/dcos_password"
+        }
+      },
+      "required": [
+        "dcos_username_secret",
+        "dcos_password_secret"
+      ]
+    },
+    "etcd": {
+      "description": "Start a 3 node etcd cluster. Required for Portworx if you don't have either etcd or consul already running. For production it is recommended to run an etcd cluster outside your DC/OS cluster.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Start etcd",
+          "description": "If disabled, please enter the external etcd server IP on the service tab.",
+          "type": "boolean",
+          "default": false
+        },
+        "proxy_enabled": {
+          "title": "Start the etcd proxy",
+          "description": "Enable if you had installed an older version of the framework which had the etcd proxy. Not required for newer installations.",
+          "type": "boolean",
+          "default": false
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        },
+        "image": {
+          "title": "Etcd Image name",
+          "type": "string",
+          "default": "mesosphere/etcd-mesos:latest"
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "CPU requirements",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk_type": {
+          "title": "Type of disk to use for persisting data",
+          "description": "ROOT or MOUNT",
+          "type": "string",
+          "default": "ROOT"
+        },
+        "disk_size": {
+          "title": "Dize of disk (MB)",
+          "type": "integer",
+          "default": 5120
+        },
+        "node_advertise_port": {
+          "title": "Cluster Node advertise port",
+          "description": "Port on which the etcd cluster nodes will listen",
+          "type": "integer",
+          "default": 1026
+        },
+        "node_peer_port": {
+          "title": "Cluster Node peer port",
+          "description": "Port on which the etcd cluster nodes will communicate with each other",
+          "type": "integer",
+          "default": 1027
+        },
+        "proxy_advertise_port": {
+          "title": "Cluster Proxy advertise port",
+          "description": "Port on which the etcd proxy will listen",
+          "type": "integer",
+          "default": 2379
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk_type",
+        "disk_size",
+        "node_advertise_port",
+        "node_peer_port",
+        "proxy_advertise_port",
+        "image"
+      ]
+    },
+    "lighthouse": {
+      "description": "Lighthouse exposes the web UI for Portworx. Start this if you don't want to connect to the central Portworx Lighthouse. \nNote: Lighthouse will work only with Portworx 1.4 and above",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Start Lighthouse",
+          "description": "Start the Lighthouse service.",
+          "type": "boolean",
+          "default": false
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": ""
+        },
+        "public_agent": {
+          "title": "public_agent",
+          "description": "Whether to run Lighthouse on a public agent or not. If you do not have a public agent, disable this option to run on a private agent. Remember, this cannot be changed once the framework is deployed.",
+          "type": "boolean",
+          "default": true
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "CPU requirements",
+          "type": "number",
+          "default": 0.3
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "image": {
+          "title": "Lighthouse Image name",
+          "type": "string",
+          "default": "portworx/px-lighthouse:2.0.1"
+        },
+        "webui_port": {
+          "title": "WebUI Port",
+          "description": "Port on which Lighthouse can be accessed",
+          "type": "integer",
+          "default": 8085
+        },
+        "company_name": {
+          "title": "Company Name",
+          "description": "Company Name to use for creating Lighthouse account",
+          "type": "string",
+          "default": "Portworx"
+        },
+        "admin_username": {
+          "title": "Administrator username",
+          "description": "Username to use for the Lighthouse account. This cannot be changed later.",
+          "type": "string",
+          "default": "admin"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "webui_port",
+        "company_name",
+        "admin_username",
+        "image"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx/1200/marathon.json.mustache
+++ b/repo/packages/P/portworx/1200/marathon.json.mustache
@@ -1,0 +1,126 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "user":"{{service.user}}",
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./portworx-scheduler/bin/portworx ./portworx-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
+  "env": {
+    "PACKAGE_NAME": "portworx",
+    "PACKAGE_VERSION": "1.3.5-2.0.3",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1552602139024",
+    "PACKAGE_BUILD_TIME_STR": "Thu Mar 14 2019 22:22:19 +0000",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+
+    "SERVICE_USER": "{{service.user}}",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+    "PRE_RESERVED_ROLE": "{{service.pre_reserved_role}}",
+    "TASK_FAILURE_TIMEOUT_MINUTES": "{{{service.task_failure_timeout_minutes}}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+    "PORTWORX_CLUSTER_NAME": "{{node.portworx_cluster}}",
+    "PORTWORX_IMAGE_NAME": "{{{node.portworx_image}}}",
+    "PORTWORX_START_PORT": "{{node.portworx_port_range_start}}",
+    "PORTWORX_OPTIONS": "{{{node.portworx_options}}}",
+
+    "INTERNAL_KVDB": "{{node.internal_kvdb}}",
+    {{^node.internal_kvdb}}
+    "ETCD_ENABLED": "{{etcd.enabled}}",
+    {{#etcd.enabled}}
+    "ETCD_PROXY_ENABLED": "{{etcd.proxy_enabled}}",
+    {{/etcd.enabled}}
+    {{^etcd.enabled}}
+    "PORTWORX_KVDB_SERVERS": "{{node.kvdb_servers}}",
+    {{/etcd.enabled}}
+    {{/node.internal_kvdb}}
+    {{#node.container_parameters}}
+    "NODE_CONTAINER_PARAMETERS": "{{{node.container_parameters}}}",
+    {{/node.container_parameters}}
+
+    "SECRETS_ENABLED": "{{secrets.enabled}}",
+    "SECRETS_DCOS_USERNAME": "{{{secrets.dcos_username_secret}}}",
+    "SECRETS_DCOS_PASSWORD": "{{{secrets.dcos_password_secret}}}",
+    {{#secrets.base_path}}
+    "SECRETS_BASE_PATH": "{{{secrets.base_path}}}",
+    {{/secrets.base_path}}
+
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    {{#service.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.secret_name}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "SYSCTL_URI": "{{resource.assets.uris.sysctl}}",
+
+    "ETCD_PLACEMENT": "{{etcd.placement_constraint}}",
+    "ETCD_CPUS": "{{etcd.cpus}}",
+    "ETCD_MEM": "{{etcd.mem}}",
+    "ETCD_DISK_TYPE": "{{etcd.disk_type}}",
+    "ETCD_DISK_SIZE": "{{etcd.disk_size}}",
+    "ETCD_IMAGE": "{{etcd.image}}",
+    "ETCD_NODE_ADVERTISE_PORT": "{{etcd.node_advertise_port}}",
+    "ETCD_NODE_PEER_PORT": "{{etcd.node_peer_port}}",
+    "ETCD_PROXY_ADVERTISE_PORT": "{{etcd.proxy_advertise_port}}",
+
+    "LIGHTHOUSE_ENABLED": "{{lighthouse.enabled}}",
+    "LIGHTHOUSE_PUBLIC_AGENT": "{{lighthouse.public_agent}}",
+    "LIGHTHOUSE_PLACEMENT": "{{lighthouse.placement_constraint}}",
+    "LIGHTHOUSE_CPUS": "{{lighthouse.cpus}}",
+    "LIGHTHOUSE_MEM": "{{lighthouse.mem}}",
+    "LIGHTHOUSE_IMAGE": "{{lighthouse.image}}",
+    "LIGHTHOUSE_HTTP_PORT": "{{lighthouse.webui_port}}",
+    "LIGHTHOUSE_COMPANY_NAME": "{{lighthouse.company_name}}",
+    "LIGHTHOUSE_ADMIN_USER": "{{lighthouse.admin_username}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx/1200/package.json
+++ b/repo/packages/P/portworx/1200/package.json
@@ -1,0 +1,38 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "1.3-1.4.2.1",
+    "1.3.1-1.4.2.1",
+    "1.3.2-1.5.1",
+    "1.3.3-1.6.1.1",
+    "1.3.4-2.0.1"
+  ],
+  "downgradesTo": [],
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx",
+  "version": "1.3.5-2.0.3",
+  "maintainer": "support@portworx.com",
+  "website": "https://www.portworx.com/",
+  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments. Portworx enables containerized applications to be persistent, portable and protected. For DCOS examples of Portworx, please see https://docs.portworx.com/scheduler/mesosphere-dcos/install.html",
+  "framework": true,
+  "selected": false,
+  "tags": [
+    "portworx",
+    "storage",
+    "data",
+    "cloud",
+    "volume",
+    "encryption",
+    "s3",
+    "database"
+  ],
+  "preInstallNotes": "NOTE: Portworx requires a key-value database such as etcd for configuring storage. A highly availbale clustered etcd with persistent storage is preferred. You can start a 3-node etcd cluster using this framework, but for production it is recommended to operate an etcd cluster outside of your DC/OS environment. Instructions to set up etcd can be found here: https://docs.portworx.com/maintain/etcd.html \n\nLighthouse is a management and GUI service that allows you to manage your Portworx cluster. Lighthouse is disabled by default and can be enabled from the Lighthouse tab during install. Default username/password for Lighthouse is portworx@yourcompany.com/admin \n\nCertified packages are verified by Mesosphere for interoperability with DC/OS. Community packages are unverified and unreviewed content from the community. This is a community package. Be aware that this particular community package installs and operates as a system process in such a way that the detailed status of that process is not directly visible through DC/OS. Monitoring and managing the PX application should only be performed directly through the PX management utility and not through the DC/OS dashboard. Please visit https://docs.portworx.com/scheduler/mesosphere-dcos/install.html for detailed instructions.",
+  "postInstallNotes": "To see how Portworx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures, please visit https://docs.portworx.com",
+  "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "Apache 2.0 License",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/repo/packages/P/portworx/1200/resource.json
+++ b/repo/packages/P/portworx/1200/resource.json
@@ -1,0 +1,64 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/portworx-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/bootstrap.zip",
+      "sysctl": "https://s3-us-west-1.amazonaws.com/px-dcos/sysCtl.tar.gz"
+    },
+    "container": {
+      "docker": {
+        "portworx": "portworx/px-enterprise:2.0.3",
+        "lighthouse": "portworx/px-lighthouse:2.0.1",
+        "etcd": "mesosphere/etcd-mesos:latest"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-small.png",
+    "icon-medium": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-medium.png",
+    "icon-large": "https://raw.githubusercontent.com/portworx/px-dev/master/images/px-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "f7397fe151e0087d948b694285f2680e9c05735fadca44970b43db05b96d96fd"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "d6a81117bb65000162d74fcf1afc3e85615dddf2295d5861efcbe7df257445fa"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "7eef69eb09650bbfa5823cabfdb049196a3cce675b7646397afc588924d91b9a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release portworx 1.3.5-2.0.3 (automated commit)

Description:
Source URL: https://px-dcos-dev.s3.amazonaws.com/autodelete7d/portworx/20190314-222217-uVKUyTWX59Wtui4I/stub-universe-portworx.json

Changes between revisions 1100 => 1200:
0 files added: []
0 files removed: []
4 files changed:

```
--- 1100/config.json
+++ 1200/config.json
@@ -42,10 +42,18 @@
             "V1"
           ],
           "default": "V1"
-        }
-      },
-      "required": [
-        "name"
+        },
+        "task_failure_timeout_minutes": {
+          "title": "Task failure timeout minutes",
+          "description": "If a task is in FAILED or LOST state for the set timeout (in minutes), the task will marked as permanently failed and new replacement task will be launched.",
+          "type": "integer",
+          "default": 5,
+          "minimum": 0
+        }
+      },
+      "required": [
+        "name",
+        "task_failure_timeout_minutes"
       ]
     },
     "node": {
@@ -60,7 +68,7 @@
         "portworx_image": {
           "title": "Portworx Image name",
           "type": "string",
-          "default": "portworx/px-enterprise:2.0.1"
+          "default": "portworx/px-enterprise:2.0.3"
         },
         "portworx_port_range_start": {
           "title": "Portworx port range start",
@@ -73,9 +81,15 @@
           "type": "string",
           "default": "-a -x mesos"
         },
+        "internal_kvdb": {
+          "title": "Internal KVDB",
+          "description": "Portworx will internally create and manage a key-value store cluster. KVDB servers or package etcd will not be used if internal KVDB is enabled. Note: Do not change this once the cluster is up.",
+          "type": "boolean",
+          "default": false
+        },
         "kvdb_servers": {
           "title": "KVDB servers",
-          "description": "Comma seperated IP:PORT entries for the key value database (etcd or consul). If the etcd server is started using the pacakge this will be ignored",
+          "description": "Comma seperated IP:PORT entries for the key value database (etcd or consul). If the etcd server is started using the package this will be ignored",
           "type": "string",
           "default": ""
         },
@@ -226,7 +240,7 @@
       "properties": {
         "enabled": {
           "title": "Start Lighthouse",
-          "description": "Start the Lighthouse service. If this is disabled the influxdb service will also be disabled.",
+          "description": "Start the Lighthouse service.",
           "type": "boolean",
           "default": false
         },
--- 1100/marathon.json.mustache
+++ 1200/marathon.json.mustache
@@ -23,15 +23,16 @@
   {{/service.secret_name}}
   "env": {
     "PACKAGE_NAME": "portworx",
-    "PACKAGE_VERSION": "1.3.4-2.0.1",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1547083638164",
-    "PACKAGE_BUILD_TIME_STR": "Thu Jan 10 2019 01:27:18 +0000",
+    "PACKAGE_VERSION": "1.3.5-2.0.3",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1552602139024",
+    "PACKAGE_BUILD_TIME_STR": "Thu Mar 14 2019 22:22:19 +0000",
     "MESOS_API_VERSION": "{{service.mesos_api_version}}",
 
     "SERVICE_USER": "{{service.user}}",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
     "PRE_RESERVED_ROLE": "{{service.pre_reserved_role}}",
+    "TASK_FAILURE_TIMEOUT_MINUTES": "{{{service.task_failure_timeout_minutes}}}",
 
     "NODE_COUNT": "{{node.count}}",
     "NODE_PLACEMENT": "{{node.placement_constraint}}",
@@ -39,6 +40,9 @@
     "PORTWORX_IMAGE_NAME": "{{{node.portworx_image}}}",
     "PORTWORX_START_PORT": "{{node.portworx_port_range_start}}",
     "PORTWORX_OPTIONS": "{{{node.portworx_options}}}",
+
+    "INTERNAL_KVDB": "{{node.internal_kvdb}}",
+    {{^node.internal_kvdb}}
     "ETCD_ENABLED": "{{etcd.enabled}}",
     {{#etcd.enabled}}
     "ETCD_PROXY_ENABLED": "{{etcd.proxy_enabled}}",
@@ -46,6 +50,7 @@
     {{^etcd.enabled}}
     "PORTWORX_KVDB_SERVERS": "{{node.kvdb_servers}}",
     {{/etcd.enabled}}
+    {{/node.internal_kvdb}}
     {{#node.container_parameters}}
     "NODE_CONTAINER_PARAMETERS": "{{{node.container_parameters}}}",
     {{/node.container_parameters}}
--- 1100/package.json
+++ 1200/package.json
@@ -4,12 +4,13 @@
     "1.3-1.4.2.1",
     "1.3.1-1.4.2.1",
     "1.3.2-1.5.1",
-    "1.3.3-1.6.1.1"
+    "1.3.3-1.6.1.1",
+    "1.3.4-2.0.1"
   ],
   "downgradesTo": [],
   "minDcosReleaseVersion": "1.9",
   "name": "portworx",
-  "version": "1.3.4-2.0.1",
+  "version": "1.3.5-2.0.3",
   "maintainer": "support@portworx.com",
   "website": "https://www.portworx.com/",
   "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments. Portworx enables containerized applications to be persistent, portable and protected. For DCOS examples of Portworx, please see https://docs.portworx.com/scheduler/mesosphere-dcos/install.html",
--- 1100/resource.json
+++ 1200/resource.json
@@ -3,14 +3,14 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
-      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.4-2.0.1/portworx-scheduler.zip",
-      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.4-2.0.1/executor.zip",
-      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.4-2.0.1/bootstrap.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/portworx-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/bootstrap.zip",
       "sysctl": "https://s3-us-west-1.amazonaws.com/px-dcos/sysCtl.tar.gz"
     },
     "container": {
       "docker": {
-        "portworx": "portworx/px-enterprise:2.0.1",
+        "portworx": "portworx/px-enterprise:2.0.3",
         "lighthouse": "portworx/px-lighthouse:2.0.1",
         "etcd": "mesosphere/etcd-mesos:latest"
       }
@@ -32,7 +32,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.4-2.0.1/dcos-service-cli-darwin"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -44,7 +44,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.4-2.0.1/dcos-service-cli-linux"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -56,7 +56,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.4-2.0.1/dcos-service-cli.exe"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx/assets/1.3.5-2.0.3/dcos-service-cli.exe"
         }
       }
     }
```
